### PR TITLE
R2 bayes changes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: performance
 Type: Package
 Title: Assessment of Regression Models Performance
-Version: 0.3.0.9000
+Version: 0.3.1.9000
 Date: 2019-08-05
 Authors@R: c(
 	person("Daniel", 
@@ -35,7 +35,7 @@ Depends:
   R (>= 3.0)
 Imports:
 	insight (>= 0.4.1),
-	bayestestR (>= 0.2.2)
+	bayestestR (>= 0.2.5)
 Suggests:
 	AER,
 	betareg,

--- a/R/model_performance.bayesian.R
+++ b/R/model_performance.bayesian.R
@@ -61,6 +61,7 @@ model_performance.stanreg <- function(model, metrics = "all", ...) {
   mi <- insight::model_info(model)
 
   out <- list()
+  attri <- list()
   if ("LOOIC" %in% c(metrics)) {
     out <- append(out, suppressWarnings(looic(model)))
   }
@@ -68,16 +69,16 @@ model_performance.stanreg <- function(model, metrics = "all", ...) {
     out$WAIC <- suppressWarnings(loo::waic(model)$estimates["waic", "Estimate"])
   }
   if ("R2" %in% c(metrics)) {
-    r2 <- .r2_posterior(model)
-    if (!is.null(r2) && !all(is.na(r2))) {
-      out <- c(out, .summarize_r2_bayes(r2$R2_Bayes, name = "R2"))
-      if ("R2_Bayes_marginal" %in% names(r2)) {
-        out <- c(out, .summarize_r2_bayes(r2$R2_Bayes_marginal, name = "R2_marginal"))
-      }
-    }
+    r2 <- r2_bayes(model, ...)
+    attri$r2_bayes <- attributes(r2) # save attributes
+
+    # Format to df then to list
+    r2_df <- as.data.frame(t(as.numeric(r2)))
+    names(r2_df) <- gsub("_Bayes", "", names(r2), fixed = TRUE)
+    out <- append(out, as.list(r2_df))
   }
   if ("R2_adjusted" %in% c(metrics) && mi$is_linear) {
-    out$R2_LOO_adjusted <- suppressWarnings(r2_loo(model))
+    out$R2_adjusted <- suppressWarnings(r2_loo(model))
   }
   if ("RMSE" %in% c(metrics) && !mi$is_ordinal && !mi$is_categorical) {
     out$RMSE <- performance_rmse(model)
@@ -95,6 +96,8 @@ model_performance.stanreg <- function(model, metrics = "all", ...) {
 
   out <- as.data.frame(out)
   row.names(out) <- NULL
+
+  attributes(out) <- c(attributes(out), attri)
   class(out) <- c("performance_model", class(out))
 
   out

--- a/R/model_performance.bayesian.R
+++ b/R/model_performance.bayesian.R
@@ -108,9 +108,3 @@ model_performance.stanreg <- function(model, metrics = "all", ...) {
 model_performance.brmsfit <- model_performance.stanreg
 
 
-#' @keywords internal
-.summarize_r2_bayes <- function(r2_posterior, name = "R2_") {
-  out <- list(mean(r2_posterior), stats::sd(r2_posterior))
-  names(out) <- paste0(name, c("", "_SE"))
-  out
-}

--- a/R/r2_bayes.R
+++ b/R/r2_bayes.R
@@ -62,14 +62,18 @@ r2_bayes <- function(model, robust = TRUE, ci = .89) {
       class = "r2_bayes_mv",
       rapply(r2_bayesian, ifelse(robust, stats::median, mean)),
       "SE" = rapply(r2_bayesian, ifelse(robust, stats::mad, stats::sd)),
-      "CI" = rapply(r2_bayesian, bayestestR::ci, ci = ci)
+      "Estimates" = rapply(r2_bayesian, bayestestR::point_estimate, centrality = "all", dispersion = TRUE),
+      "CI" = rapply(r2_bayesian, bayestestR::hdi, ci = ci),
+      "robust" = robust
     )
   } else {
     structure(
       class = "r2_bayes",
       lapply(r2_bayesian, ifelse(robust, stats::median, mean)),
       "SE" = lapply(r2_bayesian, ifelse(robust, stats::mad, stats::sd)),
-      "CI" = lapply(r2_bayesian, bayestestR::ci, ci = ci)
+      "Estimates" = lapply(r2_bayesian, bayestestR::point_estimate, centrality = "all", dispersion = TRUE),
+      "CI" = lapply(r2_bayesian, bayestestR::hdi, ci = ci),
+      "robust" = robust
     )
   }
 }

--- a/tests/testthat/test-model_performance.bayesian.R
+++ b/tests/testthat/test-model_performance.bayesian.R
@@ -11,22 +11,22 @@ if (require("testthat") && require("performance")) {
       model <- insight::download_model("stanreg_lm_1")
       perf <- model_performance(model)
 
-      expect_equal(perf$R2, 0.7423714, tolerance = 1e-4)
-      expect_equal(perf$R2_LOO_adjusted,  0.7110354, tolerance = 1e-4)
+      expect_equal(perf$R2, 0.752, tolerance = 0.01)
+      expect_equal(perf$R2_adjusted,  0.7110354, tolerance = 1e-4)
       expect_equal(perf$ELPD, -83.40375, tolerance = 1e-4)
 
       model <- insight::download_model("stanreg_lm_2")
       perf <- model_performance(model)
 
       expect_equal(perf$R2, 0.81877, tolerance = 0.01)
-      expect_equal(perf$R2_LOO_adjusted, 0.791236, tolerance = 0.01)
+      expect_equal(perf$R2_adjusted, 0.791236, tolerance = 0.01)
       expect_equal(perf$ELPD, -78.38735, tolerance = 0.01)
 
       model <- insight::download_model("stanreg_lmerMod_1")
       perf <- model_performance(model)
 
-      expect_equal(perf$R2, 0.6256033, tolerance = 0.01)
-      expect_equal(perf$R2_LOO_adjusted, 0.5896637, tolerance = 0.01)
+      expect_equal(perf$R2, 0.642, tolerance = 0.01)
+      expect_equal(perf$R2_adjusted, 0.5896637, tolerance = 0.01)
       expect_equal(perf$ELPD, -31.55849, tolerance = 0.01)
     })
 
@@ -38,13 +38,13 @@ if (require("testthat") && require("performance")) {
       model <- insight::download_model("brms_1")
       perf <- model_performance(model)
       expect_equal(perf$R2, 0.8187403, tolerance = 0.01)
-      expect_equal(perf$R2_LOO_adjusted, 0.7908548, tolerance = 0.01)
+      expect_equal(perf$R2_adjusted, 0.7908548, tolerance = 0.01)
       expect_equal(perf$ELPD, -78.43981, tolerance = 0.01)
 
       model <- insight::download_model("brms_mixed_4")
       perf <- model_performance(model)
       expect_equal(perf$R2, 0.9541836, tolerance = 0.01)
-      expect_equal(perf$R2_LOO_adjusted, 0.9524251, tolerance = 0.01)
+      expect_equal(perf$R2_adjusted, 0.9524251, tolerance = 0.01)
       expect_equal(perf$ELPD, -70.23604, tolerance = 0.01)
 
       model <- insight::download_model("brms_ordinal_1")


### PR DESCRIPTION
Minor R2 bayes adjustements for condsistency and usage by report

- store all point estimates for R2_bayes
- pass on attributes to model_performance
- Change name of r2_loo_adjusted to r2_adjusted to follow consistency of SE etc.
- still think SE should be renamed to match what is actually computed (SD or MAD)