### PR TITLE
suppress printout in model_performance.gamlss

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,7 +27,12 @@ Authors@R:
              family = "Waggoner",
              role = c("aut", "ctb"),
              email = "philip.waggoner@gmail.com",
-             comment = c(ORCID = "0000-0002-7825-7573")))
+             comment = c(ORCID = "0000-0002-7825-7573")),
+      person(given = "Vincent",
+             family = "Arel-Bundock", 
+             email = "vincent.arel-bundock@umontreal.ca", 
+             role = "ctb",
+             comment = c(ORCID = "0000-0003-2042-7063")))
 Maintainer: Daniel Lüdecke <d.luedecke@uke.de>
 Description: Utilities for computing measures to assess model quality,
     which are not directly provided by R's 'base' or 'stats' packages.

--- a/R/r2.R
+++ b/R/r2.R
@@ -463,7 +463,10 @@ r2.BFBayesFactor <- r2.brmsfit
 
 #' @export
 r2.gam <- function(model, ...) {
-  s <- summary(model)
+
+  # gamlss inherits from gam, and summary.gamlss prints results automatically
+  printout <- utils::capture.output(s <- summary(model))
+
   if (!is.null(s$r.sq)) {
     list(
       R2 = c(`Adjusted R2` = s$r.sq)


### PR DESCRIPTION
`gamlss` inherits from `gam`, and `summary.gamlss` automatically prints out a summary to the console when called. This captures the printout to ensure that `model_performance` is silent when assigned.

```{r}
library(gamlss)
library(performance)

dat <- rgamma(100, shape=1, scale=10)
mod <- gamlss(dat ~ 1, family = GA, trace = FALSE)
x <- model_performance(mod)
```