### PR TITLE
Fix typo in warning; refer to 'supported' not 'valid'

### DIFF
--- a/R/model_performance_default.R
+++ b/R/model_performance_default.R
@@ -18,7 +18,7 @@ model_performance.default <- function(model, metrics = "all", verbose = TRUE, ..
 
   if (!insight::is_model(model) || !insight::is_model_supported(model)) {
     if (isTRUE(verbose)) {
-      warning(paste0("Objects of class '", class(model)[1], "' are no valid model objects."), call. = FALSE)
+      warning(paste0("Objects of class '", class(model)[1], "' are not supported model objects."), call. = FALSE)
     }
     return(NULL)
   }


### PR DESCRIPTION
Also, in the interest of code maintainability, it might be nice to transition to using `sprintf()` instead of `paste0()` for compositing strings.

For example, here:
`sprintf("Objects of class '%1$s' are not supported model objects.", class(model)[1])`

The nice thing here is that you don't have to manage the commas and quotes to start and stop the various pieces of the string, you can just refer to the with the `%<character>` structures as stand-ins (similar to glue without named arguments). The `$<number>` bit can be used to explicitly refer to supplied values by position instead of implicitly by order.