### PR TITLE
Minor Fix: binned_residuals documentation

### DIFF
--- a/man/binned_residuals.Rd
+++ b/man/binned_residuals.Rd
@@ -50,7 +50,7 @@ Since \code{binned_residuals()} returns a data frame, the default
   action for the result is \emph{printing}. However, the `print()`-method for
   \code{binned_residuals()} actually creates a plot. For further
   modifications of the plot, use `print()` and add ggplot-layers to the
-  return values, e.g. \code{plot(binned_residuals(model)) +
+  return values, e.g. \code{print(binned_residuals(model)) +
   see::scale_color_pizza()}.
 }
 \examples{


### PR DESCRIPTION
Documentation to `binned_residuals` tells us that it returns a data frame, but the default action is `print`. The code snippet afterwards incorrectly uses `plot` instead of print. This PR fixes it.