### PR TITLE
Updating conclusion if alpha > 0.05.

### DIFF
--- a/R/check_homogeneity.R
+++ b/R/check_homogeneity.R
@@ -151,7 +151,7 @@ check_homogeneity.afex_aov <- function(x, method = "levene", ...) {
   } else if (p.val < 0.05) {
     insight::print_color(sprintf("Warning: Variances differ between groups (%s, p = %.3f).\n", method.string, p.val), "red")
   } else {
-    insight::print_color(sprintf("OK: There is insufficient evidence to say that the distributions have different variances (%s, p = %.3f).\n", method.string, p.val), "green")
+    insight::print_color(sprintf("OK: There is not clear evidence for different variances across groups (%s, p = %.3f).\n", method.string, p.val), "green")
   }
 
   attr(p.val, "object_name") <- deparse(substitute(x), width.cutoff = 500)

--- a/R/check_homogeneity.R
+++ b/R/check_homogeneity.R
@@ -96,7 +96,7 @@ check_homogeneity.default <- function(x, method = c("bartlett", "fligner", "leve
   } else if (p.val < 0.05) {
     insight::print_color(sprintf("Warning: Variances differ between groups (%s, p = %.3f).\n", method.string, p.val), "red")
   } else {
-    insight::print_color(sprintf("OK: There is insufficient evidence to say that the distributions have different variances (%s, p = %.3f).\n", method.string, p.val), "green")
+    insight::print_color(sprintf("OK: There is not clear evidence for different variances across groups (%s, p = %.3f).\n", method.string, p.val), "green")
   }
 
   attr(p.val, "object_name") <- deparse(substitute(x), width.cutoff = 500)

--- a/R/check_homogeneity.R
+++ b/R/check_homogeneity.R
@@ -96,7 +96,7 @@ check_homogeneity.default <- function(x, method = c("bartlett", "fligner", "leve
   } else if (p.val < 0.05) {
     insight::print_color(sprintf("Warning: Variances differ between groups (%s, p = %.3f).\n", method.string, p.val), "red")
   } else {
-    insight::print_color(sprintf("OK: Variances in each of the groups are the same (%s, p = %.3f).\n", method.string, p.val), "green")
+    insight::print_color(sprintf("OK: There is insufficient evidence to say that the distributions have different variances (%s, p = %.3f).\n", method.string, p.val), "green")
   }
 
   attr(p.val, "object_name") <- deparse(substitute(x), width.cutoff = 500)
@@ -151,7 +151,7 @@ check_homogeneity.afex_aov <- function(x, method = "levene", ...) {
   } else if (p.val < 0.05) {
     insight::print_color(sprintf("Warning: Variances differ between groups (%s, p = %.3f).\n", method.string, p.val), "red")
   } else {
-    insight::print_color(sprintf("OK: Variances in each of the groups are the same (%s, p = %.3f).\n", method.string, p.val), "green")
+    insight::print_color(sprintf("OK: There is insufficient evidence to say that the distributions have different variances (%s, p = %.3f).\n", method.string, p.val), "green")
   }
 
   attr(p.val, "object_name") <- deparse(substitute(x), width.cutoff = 500)


### PR DESCRIPTION
To my understanding, using Bartlett's test, you can't conclude that the variances are the same in absolute terms, you can only say there is insufficient evidence to claim otherwise. https://www.statology.org/bartletts-test/

Perhaps there is a better way to express this in the function output, but I think it's important not to mislead people who will be casually using the test without fully understanding its methodology.