### PR TITLE
ci=NULL speeds up computation

### DIFF
--- a/R/check_model_diagnostics.R
+++ b/R/check_model_diagnostics.R
@@ -186,7 +186,7 @@
   plot_data <- data.frame(
     Hat = infl$hat,
     Cooks_Distance = stats::cooks.distance(model, infl),
-    Fitted = insight::get_predicted(model),
+    Fitted = insight::get_predicted(model, ci = NULL),
     Residuals = resid,
     Std_Residuals = std_resid,
     stringsAsFactors = FALSE

--- a/R/performance_cv.R
+++ b/R/performance_cv.R
@@ -68,13 +68,13 @@ performance_cv <- function(
       method <- "holdout"
       stack <- TRUE
       test_resp <- data[, resp.name]
-      test_pred <- insight::get_predicted(model, data = data)
+      test_pred <- insight::get_predicted(model, ci = NULL, data = data)
       test_resd <- test_resp - test_pred
     } else if (method == "holdout") {
       train_i <- sample(seq_len(nrow(model_data)), size = round((1 - prop) * nrow(model_data)), replace = FALSE)
       model_upd <- stats::update(model, data = model_data[train_i,])
       test_resp <- model_data[-train_i, resp.name]
-      test_pred <- insight::get_predicted(model_upd, data = model_data[-train_i, ])
+      test_pred <- insight::get_predicted(model_upd, ci = NULL, data = model_data[-train_i, ])
       test_resd <- test_resp - test_pred
     } else if (method == "loo" && !info$is_bayesian) {
       model_response <- insight::get_response(model)
@@ -108,7 +108,7 @@ performance_cv <- function(
         stats::update(model, data = model_data[.x$train, ])
       })
       test_pred <- mapply(function(.x, .y) {
-        insight::get_predicted(.y, data = model_data[.x$test, ])
+        insight::get_predicted(.y, ci = NULL, data = model_data[.x$test, ])
       }, cv_folds, models_upd, SIMPLIFY = FALSE)
       test_resp <- lapply(cv_folds, function(.x) {
         as.data.frame(model_data[.x$test, ])[[resp.name]]

--- a/R/performance_mae.R
+++ b/R/performance_mae.R
@@ -27,7 +27,7 @@ mae <- performance_mae
 performance_mae.default <- function(model, verbose = TRUE, ...) {
   pred <- tryCatch(
     {
-      insight::get_predicted(model, verbose = verbose, ...)
+      insight::get_predicted(model, ci = NULL, verbose = verbose, ...)
     },
     error = function(e) {
       NULL

--- a/R/r2.R
+++ b/R/r2.R
@@ -77,7 +77,7 @@ r2.default <- function(model, ci = NULL, ci_method = "analytical", verbose = TRU
         resp <- datawizard::data_to_numeric(insight::get_response(model, verbose = FALSE), dummy_factors = FALSE, preserve_levels = TRUE)
       }
       mean_resp <- mean(resp, na.rm = TRUE)
-      pred <- insight::get_predicted(model, verbose = FALSE)
+      pred <- insight::get_predicted(model, ci = NULL, verbose = FALSE)
       list(R2 = 1 - sum((resp - pred)^2) / sum((resp - mean_resp)^2))
     },
     error = function(e) {


### PR DESCRIPTION
When we don't need confidence intervals, it is much faster to skip their computation.