### PR TITLE
Fix typos in warning

### DIFF
--- a/R/check_model.R
+++ b/R/check_model.R
@@ -167,13 +167,13 @@ check_model.default <- function(x,
 
 #' @export
 print.check_model <- function(x, ...) {
-  insight::check_if_installed("see", "for model diagnositic plots")
+  insight::check_if_installed("see", "for model diagnostic plots")
   NextMethod()
 }
 
 #' @export
 plot.check_model <- function(x, ...) {
-  insight::check_if_installed("see", "for model diagnositic plots")
+  insight::check_if_installed("see", "for model diagnostic plots")
   NextMethod()
 }
 


### PR DESCRIPTION
Hi @strengejacke and other members of easystats,
Big fan of your tools here :)
I've just noticed a small typo in the warning when `see` is not installed.