### PR TITLE
fix: rm additional backticks messing with styling

### DIFF
--- a/R/check_outliers.R
+++ b/R/check_outliers.R
@@ -13,7 +13,7 @@
 #'   for a description of the methods.
 #'
 #' @param x A model or a data.frame object.
-#' @param method The outlier detection method(s). Can be `"all"`` or some of
+#' @param method The outlier detection method(s). Can be `"all"` or some of
 #'   `"cook"`, `"pareto"`, `"zscore"`, `"zscore_robust"`, `"iqr"`, `"ci"`, `"eti"`,
 #'   `"hdi"`, `"bci"`, `"mahalanobis"`, `"mahalanobis_robust"`, `"mcd"`, `"ics"`,
 #'   `"optics"` or `"lof"`.


### PR DESCRIPTION
This PR removes a typo where an extra backtick was added which messed up the styling in documentation.