### PR TITLE
Fixes #496 (`check_outliers` throws error when passing multiple element to threshold list)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,8 +4,11 @@
 
 * `verbose` didn't work for `r2_bayes()` with `BFBayesFactor` objects.
 
-* Fixes issues in `check_model()` for models with convergence issues that lead
+* Fixed issues in `check_model()` for models with convergence issues that lead
   to `NA` values in residuals.
+  
+* Fixed bug in `check_outliers` whereby passing multiple elements to the 
+  threshold list generated an error (#496).
 
 # performance 0.10.0
 

--- a/R/check_outliers.R
+++ b/R/check_outliers.R
@@ -712,7 +712,7 @@ check_outliers.data.frame <- function(x,
     thresholds <- .check_outliers_thresholds(x)
   } else if (is.list(threshold)) {
     thresholds <- .check_outliers_thresholds(x)
-    thresholds[[names(threshold)]] <- threshold[[names(threshold)]]
+    thresholds[names(threshold)] <- threshold[names(threshold)]
   } else if (is.numeric(threshold)) {
     thresholds <- .check_outliers_thresholds(x)
     thresholds <- lapply(thresholds, function(x) threshold)


### PR DESCRIPTION
Fixes #496 (`check_outliers` throws error when passing multiple element to threshold list)

---

``` r
# Load library
devtools::load_all(".../forks/performance")

packageVersion("performance")
#> [1] '0.10.0.4'

check_outliers(mtcars, method = c(
  "zscore", "mahalanobis"), threshold = list(
    'zscore' = 2.5, 'mahalanobis' = 15))
#> 2 outliers detected: cases 9, 31.
#> - Based on the following methods and thresholds: zscore (2.5),
#>   mahalanobis (15).
#> - For variables: mpg, cyl, disp, hp, drat, wt, qsec, vs, am, gear, carb.
#> Note: Outliers were classified as such by at least half of the selected methods. 
#> 
#> -----------------------------------------------------------------------------
#> The following observations were considered outliers for two or more variables 
#> by at least one of the selected methods: 
#> 
#>   Row n_Zscore  n_Mahalanobis
#> 1  31        2 (Multivariate)
#> 2   9        1 (Multivariate)
#> 3  27        0 (Multivariate)
#> 4  29        0 (Multivariate)
```

<sup>Created on 2022-10-20 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>
