### PR TITLE
AIC and BIC without loglikelihood

### DIFF
--- a/R/helpers.R
+++ b/R/helpers.R
@@ -15,6 +15,10 @@
       stats::BIC(insight::get_loglikelihood(x, check_response = TRUE, REML = REML, verbose = FALSE)),
       error = function(e) NULL
     )
+    # when `get_loglikelihood()` does not work, `stats::BIC` sometimes still works (e.g., `fixest`)
+    if (is.null(out)) {
+      out <- tryCatch(stats::BIC(x), error = function(e) NULL)
+    }
   }
 
   out

--- a/R/performance_aicc.R
+++ b/R/performance_aicc.R
@@ -89,6 +89,10 @@ performance_aic.default <- function(x, estimator = "ML", verbose = TRUE, ...) {
       stats::AIC(insight::get_loglikelihood(x, check_response = TRUE, REML = REML, verbose = verbose)),
       error = function(e) NULL
     )
+    # when `get_loglikelihood()` does not work, `stats::AIC` sometimes still works (e.g., `fixest`)
+    if (is.null(aic)) {
+      aic <- tryCatch(stats::AIC(x), error = function(e) NULL)
+    }
   }
   aic
 }


### PR DESCRIPTION
In some models, `get_loglikelihood()` does not work, but `stats::AIC` and `stats::BIC` can still return useable results. For example, fixest:

```r
library(fixest)
mod <- feols(mpg ~ hp, data = mtcars)
stats::AIC(mod)
stats::BIC(mod)
```