### PR TITLE
Recursion in `logLik.plm()` that slows down computations:

### DIFF
--- a/R/logLik.R
+++ b/R/logLik.R
@@ -55,7 +55,7 @@ logLik.plm <- function(object, ...) {
 
   attr(val, "nall") <- N0
   attr(val, "nobs") <- N
-  attr(val, "df") <- insight::n_parameters(object) + 1
+  attr(val, "df") <- insight::n_parameters(object) + 1L
   class(val) <- "logLik"
 
   val

--- a/R/logLik.R
+++ b/R/logLik.R
@@ -55,7 +55,7 @@ logLik.plm <- function(object, ...) {
 
   attr(val, "nall") <- N0
   attr(val, "nobs") <- N
-  attr(val, "df") <- insight::get_df(object, type = "model")
+  attr(val, "df") <- insight::n_parameters(object) + 1
   class(val) <- "logLik"
 
   val

--- a/tests/testthat/test-logLik.R
+++ b/tests/testthat/test-logLik.R
@@ -1,5 +1,7 @@
 test_that("logLik", {
   skip_if_not_installed("plm")
+  skip_if_not_installed("withr")
+  
   expr <- getOption("expressions")
   options(expressions = 25)
   set.seed(1)

--- a/tests/testthat/test-logLik.R
+++ b/tests/testthat/test-logLik.R
@@ -2,8 +2,7 @@ test_that("logLik", {
   skip_if_not_installed("plm")
   skip_if_not_installed("withr")
   
-  expr <- getOption("expressions")
-  options(expressions = 25)
+  withr::local_options(list(expressions = 25))
   set.seed(1)
   nnn <- 100
   ddta <- data.frame(

--- a/tests/testthat/test-logLik.R
+++ b/tests/testthat/test-logLik.R
@@ -24,5 +24,4 @@ test_that("logLik", {
   )
   l2 <- logLik(m2)
   expect_equal(l1, l2, tolerance = 1e-3, ignore_attr = TRUE)
-  options(expressions = expr)
 })

--- a/tests/testthat/test-logLik.R
+++ b/tests/testthat/test-logLik.R
@@ -1,0 +1,27 @@
+test_that("logLik", {
+  skip_if_not_installed("plm")
+  expr <- getOption("expressions")
+  options(expressions = 25)
+  set.seed(1)
+  nnn <- 100
+  ddta <- data.frame(
+    x1 = rnorm(nnn),
+    x2 = rnorm(nnn),
+    id = rep_len(1:(nnn / 10), nnn),
+    year = rep_len(1:11, nnn)
+  )
+  ddta$y <- ddta$x1 * 0.5 - ddta$x2 * 0.5 + rnorm(nnn)
+
+  m1 <- lm(y ~ x1 + x2, data = ddta)
+  l1 <- logLik(m1)
+
+  m2 <- plm(
+    y ~ x1 + x2,
+    data = ddta,
+    model = "pooling",
+    index = c("id", "year")
+  )
+  l2 <- logLik(m2)
+  expect_equal(l1, l2, tolerance = 1e-3, ignore_attr = TRUE)
+  options(expressions = expr)
+})

--- a/tests/testthat/test-logLik.R
+++ b/tests/testthat/test-logLik.R
@@ -1,7 +1,7 @@
 test_that("logLik", {
   skip_if_not_installed("plm")
   skip_if_not_installed("withr")
-  
+
   withr::local_options(list(expressions = 25))
   set.seed(1)
   nnn <- 100


### PR DESCRIPTION
Fixes #622