### PR TITLE
Fixes bug in outlier plot method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,54 +1,41 @@
 # History files
 .Rhistory
 .Rapp.history
-
 # Session Data files
 .RData
-
 # Example code in package build process
 *-Ex.R
-
 # Output files from R CMD build
 /*.tar.gz
-
 # Output files from R CMD check
 /*.Rcheck/
 /revdep/
 revdep
-
 # RStudio files
 .Rproj.user/
 *.Rproj
-
 # produced vignettes
 vignettes/*.html
 vignettes/*.pdf
-
 # OAuth2 token, see https://github.com/hadley/httr/releases/tag/v0.3
 .httr-oauth
-
 # knitr and R markdown default cache directories
 /*_cache/
 /cache/
-
 # Temporary files created by R markdown
 *.utf8.md
 *.knit.md
-
 # Shiny token, see https://shiny.rstudio.com/articles/shinyapps.html
 rsconnect/
 inst/doc
-
 =========================
 # Operating System Files
 # OSX
 .DS_Store
 .AppleDouble
 .LSOverride
-
 # Thumbnails
 ._*
-
 # Files that might appear in the root of a volume
 .DocumentRevisions-V100
 .fseventsd
@@ -56,10 +43,10 @@ inst/doc
 .TemporaryItems
 .Trashes
 .VolumeIcon.icns
-
 # Directories potentially created on remote AFP share
 .AppleDB
 .AppleDesktop
 Network Trash Folder
 Temporary Items
 .apdisk
+.Rprofile

--- a/R/check_outliers.R
+++ b/R/check_outliers.R
@@ -586,7 +586,7 @@ check_outliers.default <- function(x,
   attr(outlier, "threshold") <- thresholds
   attr(outlier, "method") <- method
   attr(outlier, "text_size") <- 3
-  attr(outlier, "influential_obs") <- .influential_obs(x)
+  attr(outlier, "influential_obs") <- .influential_obs(x, threshold = unlist(thresholds))
   attr(outlier, "variables") <- "(Whole model)"
   attr(outlier, "raw_data") <- my_data
   attr(outlier, "outlier_var") <- outlier_var

--- a/R/check_outliers.R
+++ b/R/check_outliers.R
@@ -255,29 +255,29 @@
 #' @references
 #' - Archimbaud, A., Nordhausen, K., and Ruiz-Gazen, A. (2018). ICS for
 #' multivariate outlier detection with application to quality control.
-#' Computational Statistics and Data Analysis, 128, 184-199.
+#' *Computational Statistics and Data Analysis*, *128*, 184-199.
 #' \doi{10.1016/j.csda.2018.06.011}
 #'
 #' - Gnanadesikan, R., and Kettenring, J. R. (1972). Robust estimates, residuals,
-#' and outlier detection with multiresponse data. Biometrics, 81-124.
+#' and outlier detection with multiresponse data. *Biometrics*, 81-124.
 #'
 #' - Bollen, K. A., and Jackman, R. W. (1985). Regression diagnostics: An
-#' expository treatment of outliers and influential cases. Sociological Methods
-#' and Research, 13(4), 510-542.
+#' expository treatment of outliers and influential cases. *Sociological Methods
+#' and Research*, *13*(4), 510-542.
 #'
 #' - Cabana, E., Lillo, R. E., and Laniado, H. (2019). Multivariate outlier
 #' detection based on a robust Mahalanobis distance with shrinkage estimators.
 #' arXiv preprint arXiv:1904.02596.
 #'
 #' - Cook, R. D. (1977). Detection of influential observation in linear
-#' regression. Technometrics, 19(1), 15-18.
+#' regression. *Technometrics*, *19*(1), 15-18.
 #'
 #' - Iglewicz, B., and Hoaglin, D. C. (1993). How to detect and handle outliers
 #' (Vol. 16). Asq Press.
 #'
 #' - Leys, C., Klein, O., Dominicy, Y., and Ley, C. (2018). Detecting
-#' multivariate outliers: Use a robust variant of Mahalanobis distance. Journal
-#' of Experimental Social Psychology, 74, 150-156.
+#' multivariate outliers: Use a robust variant of Mahalanobis distance. *Journal
+#' of Experimental Social Psychology*, 74, 150-156.
 #'
 #' - Liu, F. T., Ting, K. M., and Zhou, Z. H. (2008, December). Isolation forest.
 #' In 2008 Eighth IEEE International Conference on Data Mining (pp. 413-422).
@@ -285,16 +285,17 @@
 #'
 #' - Lüdecke, D., Ben-Shachar, M. S., Patil, I., Waggoner, P., and Makowski, D.
 #' (2021). performance: An R package for assessment, comparison and testing of
-#' statistical models. Journal of Open Source Software, 6(60), 3139.
+#' statistical models. *Journal of Open Source Software*, *6*(60), 3139.
 #' \doi{10.21105/joss.03139}
 #'
 #' - Thériault, R., Ben-Shachar, M. S., Patil, I., Lüdecke, D., Wiernik, B. M.,
 #' and Makowski, D. (2023). Check your outliers! An introduction to identifying
-#' statistical outliers in R with easystats. \doi{10.31234/osf.io/bu6nt}
+#' statistical outliers in R with easystats. *Behavior Research Methods*, 1-11.
+#' \doi{10.3758/s13428-024-02356-w}
 #'
 #' - Rousseeuw, P. J., and Van Zomeren, B. C. (1990). Unmasking multivariate
-#' outliers and leverage points. Journal of the American Statistical
-#' association, 85(411), 633-639.
+#' outliers and leverage points. *Journal of the American Statistical
+#' association*, *85*(411), 633-639.
 #'
 #' @examples
 #' data <- mtcars # Size nrow(data) = 32
@@ -331,8 +332,9 @@
 #' # We can run the function stratified by groups using `{datawizard}` package:
 #' group_iris <- datawizard::data_group(iris, "Species")
 #' check_outliers(group_iris)
-#'
+#' # nolint start
 #' @examplesIf require("see") && require("bigutilsr") && require("loo") && require("MASS") && require("ICSOutlier") && require("ICS") && require("dbscan")
+#' # nolint end
 #' \donttest{
 #' # You can also run all the methods
 #' check_outliers(data, method = "all", verbose = FALSE)

--- a/man/check_outliers.Rd
+++ b/man/check_outliers.Rd
@@ -331,8 +331,9 @@ filtered_data <- data[outliers_info$Outlier < 0.1, ]
 # We can run the function stratified by groups using `{datawizard}` package:
 group_iris <- datawizard::data_group(iris, "Species")
 check_outliers(group_iris)
-
+# nolint start
 \dontshow{if (require("see") && require("bigutilsr") && require("loo") && require("MASS") && require("ICSOutlier") && require("ICS") && require("dbscan")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+# nolint end
 \donttest{
 # You can also run all the methods
 check_outliers(data, method = "all", verbose = FALSE)
@@ -359,36 +360,37 @@ insight::get_data(model)[outliers_list, ] # Show outliers data
 \itemize{
 \item Archimbaud, A., Nordhausen, K., and Ruiz-Gazen, A. (2018). ICS for
 multivariate outlier detection with application to quality control.
-Computational Statistics and Data Analysis, 128, 184-199.
+\emph{Computational Statistics and Data Analysis}, \emph{128}, 184-199.
 \doi{10.1016/j.csda.2018.06.011}
 \item Gnanadesikan, R., and Kettenring, J. R. (1972). Robust estimates, residuals,
-and outlier detection with multiresponse data. Biometrics, 81-124.
+and outlier detection with multiresponse data. \emph{Biometrics}, 81-124.
 \item Bollen, K. A., and Jackman, R. W. (1985). Regression diagnostics: An
-expository treatment of outliers and influential cases. Sociological Methods
-and Research, 13(4), 510-542.
+expository treatment of outliers and influential cases. \emph{Sociological Methods
+and Research}, \emph{13}(4), 510-542.
 \item Cabana, E., Lillo, R. E., and Laniado, H. (2019). Multivariate outlier
 detection based on a robust Mahalanobis distance with shrinkage estimators.
 arXiv preprint arXiv:1904.02596.
 \item Cook, R. D. (1977). Detection of influential observation in linear
-regression. Technometrics, 19(1), 15-18.
+regression. \emph{Technometrics}, \emph{19}(1), 15-18.
 \item Iglewicz, B., and Hoaglin, D. C. (1993). How to detect and handle outliers
 (Vol. 16). Asq Press.
 \item Leys, C., Klein, O., Dominicy, Y., and Ley, C. (2018). Detecting
-multivariate outliers: Use a robust variant of Mahalanobis distance. Journal
-of Experimental Social Psychology, 74, 150-156.
+multivariate outliers: Use a robust variant of Mahalanobis distance. \emph{Journal
+of Experimental Social Psychology}, 74, 150-156.
 \item Liu, F. T., Ting, K. M., and Zhou, Z. H. (2008, December). Isolation forest.
 In 2008 Eighth IEEE International Conference on Data Mining (pp. 413-422).
 IEEE.
 \item Lüdecke, D., Ben-Shachar, M. S., Patil, I., Waggoner, P., and Makowski, D.
 (2021). performance: An R package for assessment, comparison and testing of
-statistical models. Journal of Open Source Software, 6(60), 3139.
+statistical models. \emph{Journal of Open Source Software}, \emph{6}(60), 3139.
 \doi{10.21105/joss.03139}
 \item Thériault, R., Ben-Shachar, M. S., Patil, I., Lüdecke, D., Wiernik, B. M.,
 and Makowski, D. (2023). Check your outliers! An introduction to identifying
-statistical outliers in R with easystats. \doi{10.31234/osf.io/bu6nt}
+statistical outliers in R with easystats. \emph{Behavior Research Methods}, 1-11.
+\doi{10.3758/s13428-024-02356-w}
 \item Rousseeuw, P. J., and Van Zomeren, B. C. (1990). Unmasking multivariate
-outliers and leverage points. Journal of the American Statistical
-association, 85(411), 633-639.
+outliers and leverage points. \emph{Journal of the American Statistical
+association}, \emph{85}(411), 633-639.
 }
 }
 \seealso{


### PR DESCRIPTION
Closes #711

---
``` r
# Prepare model
library(see)
library(lme4)
library(performance)
set.seed(123)  # for reproducibility
n <- 100
subjectID <- paste("Subject", rep(1:10, each = 10))
PN <- runif(n, 0, 100)
alpha <- 0.5 * PN + rnorm(n, mean = 50, sd = 10)
alpha[c(20, 40)] <- c(150, 160)  # arbitrarily chosen subjects for outliers
data <- data.frame(subjectID, PN, alpha)
model <- lmer(alpha ~ PN + (1 | subjectID), data = data)

# Test
x <- check_outliers(model)
plot(x)
```

![](https://i.imgur.com/myyT5qo.png)<!-- -->

<sup>Created on 2024-04-28 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>
