### PR TITLE
check_predictions() fails when outcome is log-transformed and named like a valid function

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: performance
 Title: Assessment of Regression Models Performance
-Version: 0.12.0.9
+Version: 0.12.0.10
 Authors@R:
     c(person(given = "Daniel",
              family = "Lüdecke",

--- a/R/check_predictions.R
+++ b/R/check_predictions.R
@@ -510,7 +510,7 @@ plot.performance_pp_check <- function(x, ...) {
     if (is.null(plus_minus)) {
       plus_minus <- .safe(eval(parse(text = gsub("log\\(([^,\\+)]*)(.*)\\)", "\\1", resp_string))))
     }
-    if (is.null(plus_minus)) {
+    if (is.null(plus_minus) || !is.numeric(plus_minus)) {
       sims[] <- lapply(sims, exp)
     } else {
       sims[] <- lapply(sims, function(i) exp(i) - plus_minus)

--- a/tests/testthat/test-check_model.R
+++ b/tests/testthat/test-check_model.R
@@ -108,3 +108,13 @@ test_that("`check_model()` no warnings for quasipoisson", {
   expect_message(check_model(model1, verbose = TRUE), regex = "Not enough")
   expect_silent(check_model(model1))
 })
+
+
+test_that("`check_model()` with transformed response when named as function", {
+  data(mtcars)
+  # rename variable, so it equals to a valid R function
+  mtcars$rt <- mtcars$mpg
+  model <- lm(log(rt) ~ disp, data = mtcars)
+  out <- check_predictions(model)
+  expect_s3_class(out, "performance_pp_check")
+})


### PR DESCRIPTION
Fixes #722