### PR TITLE
Fix issues with multiple possible adjustments

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: performance
 Title: Assessment of Regression Models Performance
-Version: 0.12.2.8
+Version: 0.12.2.9
 Authors@R:
     c(person(given = "Daniel",
              family = "Lüdecke",

--- a/R/check_dag.R
+++ b/R/check_dag.R
@@ -307,7 +307,7 @@ print.check_dag <- function(x, ...) {
     # options for minimal adjustements, so we check here if any of the minimal
     # adjustements are currently sufficient
     missing_adjustments <- vapply(out$minimal_adjustments, function(i) {
-      !is.null(out$current_adjustments) && all(out$current_adjustments %in% i)
+      !is.null(out$current_adjustments) && all(i %in% out$current_adjustments)
     }, logical(1))
 
     # build message with check results for effects -----------------------

--- a/tests/testthat/_snaps/check_dag.md
+++ b/tests/testthat/_snaps/check_dag.md
@@ -128,3 +128,54 @@
       All minimal sufficient adjustments to estimate the total effect were done.
       
 
+# check_dag, multiple adjustment sets
+
+    Code
+      print(dag)
+    Output
+      # Check for correct adjustment sets
+      - Outcome: exam
+      - Exposure: podcast
+      
+      Identification of direct effects
+      
+      Incorrectly adjusted!
+      To estimate the direct effect, also adjust for one of the following sets:
+      - alertness, prepared
+      - alertness, skills_course
+      - mood, prepared
+      - mood, skills_course.
+      Currently, the model does not adjust for any variables.
+      
+      Identification of total effects
+      
+      Incorrectly adjusted!
+      To estimate the total effect, also adjust for one of the following sets:
+      - alertness, prepared
+      - alertness, skills_course
+      - mood, prepared
+      - mood, skills_course.
+      Currently, the model does not adjust for any variables.
+      
+
+---
+
+    Code
+      print(dag)
+    Output
+      # Check for correct adjustment sets
+      - Outcome: exam
+      - Exposure: podcast
+      - Adjustments: alertness and prepared
+      
+      Identification of direct effects
+      
+      Model is correctly specified.
+      All minimal sufficient adjustments to estimate the direct effect were done.
+      
+      Identification of total effects
+      
+      Model is correctly specified.
+      All minimal sufficient adjustments to estimate the total effect were done.
+      
+

--- a/tests/testthat/test-check_dag.R
+++ b/tests/testthat/test-check_dag.R
@@ -47,7 +47,6 @@ test_that("check_dag", {
     wt ~ disp + cyl,
     wt ~ am
   )
-  dag
   expect_snapshot(print(dag))
 })
 
@@ -64,4 +63,31 @@ test_that("check_dag, cylic error", {
     ),
     regex = "Model is cyclic"
   )
+})
+
+
+test_that("check_dag, multiple adjustment sets", {
+  dag <- check_dag(
+    podcast ~ mood + humor + skills_course,
+    alertness ~ mood,
+    mood ~ humor,
+    prepared ~ skills_course,
+    exam ~ alertness + prepared,
+    coords = ggdag::time_ordered_coords(),
+    exposure = "podcast",
+    outcome = "exam"
+  )
+  expect_snapshot(print(dag))
+  dag <- check_dag(
+    podcast ~ mood + humor + skills_course,
+    alertness ~ mood,
+    mood ~ humor,
+    prepared ~ skills_course,
+    exam ~ alertness + prepared,
+    adjusted = c("alertness", "prepared"),
+    exposure = "podcast",
+    outcome = "exam",
+    coords = ggdag::time_ordered_coords()
+  )
+  expect_snapshot(print(dag))
 })


### PR DESCRIPTION
```r
dag <- check_dag(
  podcast ~ mood + humor + skills_course,
  alertness ~ mood,
  mood ~ humor,
  prepared ~ skills_course,
  exam ~ alertness + prepared,
  exposure = "podcast",
  outcome = "exam",
  coords = time_ordered_coords()
)
dag


dag <- check_dag(
  podcast ~ mood + humor + skills_course,
  alertness ~ mood,
  mood ~ humor,
  prepared ~ skills_course,
  exam ~ alertness + prepared,
  adjusted = c("alertness", "prepared"),
  exposure = "podcast",
  outcome = "exam",
  coords = time_ordered_coords()
)
dag
```