### PR TITLE
Ptint DAG result only once if identical

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: performance
 Title: Assessment of Regression Models Performance
-Version: 0.12.2.9
+Version: 0.12.2.10
 Authors@R:
     c(person(given = "Daniel",
              family = "Lüdecke",

--- a/R/check_dag.R
+++ b/R/check_dag.R
@@ -66,6 +66,7 @@
 #' to remove cycles from the model.
 #'
 #' @section Direct and total effects:
+#'
 #' The direct effect of an exposure on an outcome is the effect that is not
 #' mediated by any other variable in the model. The total effect is the sum of
 #' the direct and indirect effects. The function checks if the model is correctly
@@ -413,7 +414,7 @@ print.check_dag <- function(x, ...) {
 
   if (effect %in% c("all", i)) {
     cat(insight::print_color(insight::format_message(
-      paste0("Identification of {.i ", i, "} effects\n\n")
+      paste0("Identification of ", i, " effects\n\n")
     ), "blue"))
     cat(msg)
     cat("\n\n")

--- a/R/check_dag.R
+++ b/R/check_dag.R
@@ -316,16 +316,21 @@ print.check_dag <- function(x, ...) {
   cat(exposure_outcome_text)
   cat("\n\n")
 
-  for (i in c("direct", "total")) {
-    if (i == "direct") {
-      out <- attributes(x)$check_direct
-    } else {
-      out <- attributes(x)$check_total
+  # minimal adjustment sets for direct and total effect identical?
+  # Then print only once
+  if (identical(attributes(x)$check_direct$minimal_adjustments, attributes(x)$check_total$minimal_adjustments)) {
+    .print_dag_results(attributes(x)$check_direct, x, "direct and total", "all")
+  } else {
+    for (i in c("direct", "total")) {
+      if (i == "direct") {
+        out <- attributes(x)$check_direct
+      } else {
+        out <- attributes(x)$check_total
+      }
+      .print_dag_results(out, x, i, effect)
     }
-    .print_dag_results(out, x, i, effect)
   }
 }
-
 
 .print_dag_results <- function(out, x, i, effect) {
   # missing adjustements - minimal_adjustment can be a list of different

--- a/man/check_dag.Rd
+++ b/man/check_dag.Rd
@@ -101,6 +101,7 @@ to remove cycles from the model.
 
 \section{Direct and total effects}{
 
+
 The direct effect of an exposure on an outcome is the effect that is not
 mediated by any other variable in the model. The total effect is the sum of
 the direct and indirect effects. The function checks if the model is correctly

--- a/tests/testthat/_snaps/check_dag.md
+++ b/tests/testthat/_snaps/check_dag.md
@@ -7,15 +7,10 @@
       - Outcome: y
       - Exposure: x
       
-      Identification of direct effects
+      Identification of {.i direct and total} effects
       
       Model is correctly specified.
-      No adjustment needed to estimate the direct effect of `x` on `y`.
-      
-      Identification of total effects
-      
-      Model is correctly specified.
-      No adjustment needed to estimate the total effect of `x` on `y`.
+      No adjustment needed to estimate the direct and total effect of `x` on `y`.
       
 
 ---
@@ -28,15 +23,10 @@
       - Exposure: x
       - Adjustment: b
       
-      Identification of direct effects
+      Identification of {.i direct and total} effects
       
       Model is correctly specified.
-      All minimal sufficient adjustments to estimate the direct effect were done.
-      
-      Identification of total effects
-      
-      Model is correctly specified.
-      All minimal sufficient adjustments to estimate the total effect were done.
+      All minimal sufficient adjustments to estimate the direct and total effect were done.
       
 
 ---
@@ -48,16 +38,10 @@
       - Outcome: y
       - Exposure: x
       
-      Identification of direct effects
+      Identification of {.i direct and total} effects
       
       Incorrectly adjusted!
-      To estimate the direct effect, also adjust for `b`.
-      Currently, the model does not adjust for any variables.
-      
-      Identification of total effects
-      
-      Incorrectly adjusted!
-      To estimate the total effect, also adjust for `b`.
+      To estimate the direct and total effect, at least adjust for `b`.
       Currently, the model does not adjust for any variables.
       
 
@@ -71,16 +55,10 @@
       - Exposure: x
       - Adjustment: c
       
-      Identification of direct effects
+      Identification of {.i direct and total} effects
       
       Incorrectly adjusted!
-      To estimate the direct effect, also adjust for `b` and `c`.
-      Currently, the model only adjusts for `c`.
-      
-      Identification of total effects
-      
-      Incorrectly adjusted!
-      To estimate the total effect, also adjust for `b` and `c`.
+      To estimate the direct and total effect, at least adjust for `b` and `c`.
       Currently, the model only adjusts for `c`.
       
 
@@ -94,16 +72,10 @@
       - Exposure: x
       - Adjustment: c
       
-      Identification of direct effects
+      Identification of {.i direct and total} effects
       
       Incorrectly adjusted!
-      To estimate the direct effect, also adjust for `b` and `c`.
-      Currently, the model only adjusts for `c`.
-      
-      Identification of total effects
-      
-      Incorrectly adjusted!
-      To estimate the total effect, also adjust for `b` and `c`.
+      To estimate the direct and total effect, at least adjust for `b` and `c`.
       Currently, the model only adjusts for `c`.
       
 
@@ -117,15 +89,10 @@
       - Exposure: wt
       - Adjustments: cyl, disp and gear
       
-      Identification of direct effects
+      Identification of {.i direct and total} effects
       
       Model is correctly specified.
-      All minimal sufficient adjustments to estimate the direct effect were done.
-      
-      Identification of total effects
-      
-      Model is correctly specified.
-      All minimal sufficient adjustments to estimate the total effect were done.
+      All minimal sufficient adjustments to estimate the direct and total effect were done.
       
 
 # check_dag, multiple adjustment sets
@@ -137,20 +104,10 @@
       - Outcome: exam
       - Exposure: podcast
       
-      Identification of direct effects
+      Identification of {.i direct and total} effects
       
       Incorrectly adjusted!
-      To estimate the direct effect, also adjust for one of the following sets:
-      - alertness, prepared
-      - alertness, skills_course
-      - mood, prepared
-      - mood, skills_course.
-      Currently, the model does not adjust for any variables.
-      
-      Identification of total effects
-      
-      Incorrectly adjusted!
-      To estimate the total effect, also adjust for one of the following sets:
+      To estimate the direct and total effect, at least adjust for one of the following sets:
       - alertness, prepared
       - alertness, skills_course
       - mood, prepared
@@ -168,14 +125,9 @@
       - Exposure: podcast
       - Adjustments: alertness and prepared
       
-      Identification of direct effects
+      Identification of {.i direct and total} effects
       
       Model is correctly specified.
-      All minimal sufficient adjustments to estimate the direct effect were done.
-      
-      Identification of total effects
-      
-      Model is correctly specified.
-      All minimal sufficient adjustments to estimate the total effect were done.
+      All minimal sufficient adjustments to estimate the direct and total effect were done.
       
 

--- a/tests/testthat/_snaps/check_dag.md
+++ b/tests/testthat/_snaps/check_dag.md
@@ -7,7 +7,7 @@
       - Outcome: y
       - Exposure: x
       
-      Identification of {.i direct and total} effects
+      Identification of direct and total effects
       
       Model is correctly specified.
       No adjustment needed to estimate the direct and total effect of `x` on `y`.
@@ -23,7 +23,7 @@
       - Exposure: x
       - Adjustment: b
       
-      Identification of {.i direct and total} effects
+      Identification of direct and total effects
       
       Model is correctly specified.
       All minimal sufficient adjustments to estimate the direct and total effect were done.
@@ -38,7 +38,7 @@
       - Outcome: y
       - Exposure: x
       
-      Identification of {.i direct and total} effects
+      Identification of direct and total effects
       
       Incorrectly adjusted!
       To estimate the direct and total effect, at least adjust for `b`.
@@ -55,7 +55,7 @@
       - Exposure: x
       - Adjustment: c
       
-      Identification of {.i direct and total} effects
+      Identification of direct and total effects
       
       Incorrectly adjusted!
       To estimate the direct and total effect, at least adjust for `b` and `c`.
@@ -72,7 +72,7 @@
       - Exposure: x
       - Adjustment: c
       
-      Identification of {.i direct and total} effects
+      Identification of direct and total effects
       
       Incorrectly adjusted!
       To estimate the direct and total effect, at least adjust for `b` and `c`.
@@ -89,7 +89,7 @@
       - Exposure: wt
       - Adjustments: cyl, disp and gear
       
-      Identification of {.i direct and total} effects
+      Identification of direct and total effects
       
       Model is correctly specified.
       All minimal sufficient adjustments to estimate the direct and total effect were done.
@@ -104,7 +104,7 @@
       - Outcome: exam
       - Exposure: podcast
       
-      Identification of {.i direct and total} effects
+      Identification of direct and total effects
       
       Incorrectly adjusted!
       To estimate the direct and total effect, at least adjust for one of the following sets:
@@ -125,7 +125,7 @@
       - Exposure: podcast
       - Adjustments: alertness and prepared
       
-      Identification of {.i direct and total} effects
+      Identification of direct and total effects
       
       Model is correctly specified.
       All minimal sufficient adjustments to estimate the direct and total effect were done.


### PR DESCRIPTION
Currentyl, msg for direct and total effect are printed, even if adjustment sets are identica.l This PR aims at printing message only once for both direct and total effect.