### PR TITLE
[Fix] check_outliers() expose 'xi' parameter for OPTICS

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: performance
 Title: Assessment of Regression Models Performance
-Version: 0.12.4.12
+Version: 0.12.4.13
 Authors@R:
     c(person(given = "Daniel",
              family = "Lüdecke",

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,9 @@
 
 ## Breaking changes
 
+* `check_outliers()` with `method = "optics"` now returns a further refined
+  cluster selection, by passing the `optics_xi` argument to `dbscan::extractXi()`.
+
 * Deprecated arguments and alias-function-names have been removed.
 
 * Argument names in `check_model()` that refer to plot-aesthetics (like

--- a/R/check_outliers.R
+++ b/R/check_outliers.R
@@ -903,6 +903,7 @@ check_outliers.data.frame <- function(x,
   valid <- method
   if("optics" %in% valid) {
     valid <- c(valid, "optics_xi")
+    method <- c(method, "optics_xi")
   }
   thresholds <- thresholds[names(thresholds) %in% valid]
 

--- a/R/check_outliers.R
+++ b/R/check_outliers.R
@@ -883,6 +883,13 @@ check_outliers.data.frame <- function(x,
   } else if (is.numeric(threshold)) {
     thresholds <- .check_outliers_thresholds(x)
     thresholds <- lapply(thresholds, function(x) threshold)
+    # need to fix this manually - "optics" automatically includes method
+    # "optics_xi", which is allowed to range between 0 and 1 - since values
+    # for "optics" can be > 1, it might overwrite "optics_xi" with an invalid
+    # value...
+    if (thresholds$optics_xi > 1) {
+      thresholds$optics_xi <- 0.05
+    }
   } else {
     insight::format_error(
       paste(

--- a/man/check_outliers.Rd
+++ b/man/check_outliers.Rd
@@ -236,7 +236,8 @@ detect several outliers (as these are usually defined as a percentage of
 extreme values), this algorithm functions in a different manner and won't
 always detect outliers. Note that \code{method = "optics"} requires the
 \strong{dbscan} package to be installed, and that it takes some time to compute
-the results.
+the results. Additionally, the \code{optics_xi} (default to 0.05) is passed to
+the \code{\link[dbscan:optics]{dbscan::extractXi()}} function to further refine the cluster selection.
 \item \strong{Local Outlier Factor}:
 Based on a K nearest neighbors algorithm, LOF compares the local density of
 a point to the local densities of its neighbors instead of computing a
@@ -283,6 +284,7 @@ Default thresholds are currently specified as follows:
   mcd = stats::qchisq(p = 1 - 0.001, df = ncol(x)),
   ics = 0.001,
   optics = 2 * ncol(x),
+  optics_xi = 0.05,
   lof = 0.001
 )
 }\if{html}{\out{</div>}}


### PR DESCRIPTION
I have a nice new dataset of a questionnaire validation that included attention checks. I have been playing with check_outliers(), and the OPTICS method. Interestingly, the current rule for its *threshold* that we have didn't work at all, + I had to change `xi`  to actually make it work (hence this PR that allows to do that).

Interestingly though, we typically consider outliers observations with a **large** distance, but my data shows that people that have failed  attention checks (i.e., "objective" outliers) tend  to have a low distance:

![image](https://github.com/user-attachments/assets/1c9d465c-9dd6-4470-a667-b7447ffc0ff9)

(the logistic model failed ~ distance_optics makes it a significant predictor of failure)

I wouldn't recommend any action for now, maybe we can simply mention this observation (that it is possible that low distances are also problematic) once my paper is published and link to it