### PR TITLE
Revert nested change

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: performance
 Title: Assessment of Regression Models Performance
-Version: 0.13.0.9
+Version: 0.13.0.10
 Authors@R:
     c(person(given = "Daniel",
              family = "Lüdecke",

--- a/R/check_group_variation.R
+++ b/R/check_group_variation.R
@@ -265,22 +265,42 @@ print_html.check_group_variation <- function(x, ...) {
 
 
 #' @export
-summary.check_group_variation <- function(object, ...) {
-  # TODO if more than one group, show which group(s)
-  result <- unique(object$Variable[startsWith(object$Variation, "both")])
+#' @rdname check_group_variation
+#' @param object result from `check_group_variation()`
+#' @param flatten Logical, if `TRUE`, the values are returned as character vector, not as list. Duplicated values are removed.
+summary.check_group_variation <- function(object, flatten = FALSE, ...) {
 
-  if (length(result)) {
-    insight::format_alert(paste(
-      "Possible heterogeneity bias due to following predictors:",
-      insight::color_text(toString(result), "red")
+  i <- which(object$Variation %in% "both")
+
+  if (length(i)) {
+    object <- object[i,,drop = FALSE]
+
+    result <- split(object$Variable, object$Group)
+    if (length(result) > 1L) {
+
+      txt <- paste0("- ", names(result), ": ", sapply(result, paste0, collapse = ", "), collapse = "\n")
+    } else {
+      txt <- paste0("- ", paste0(result[[1]], collapse = ", "))
+    }
+
+    insight::format_alert(paste0(
+      "Possible heterogeneity bias due to following predictors:\n",
+      insight::color_text(txt, "red")
     ))
+
+    if (flatten) {
+      return(invisible(unique(unlist(result, use.names = FALSE))))
+    } else {
+      return(invisible(result))
+    }
+
   } else {
     insight::format_alert(insight::color_text(
       "No predictor found that could cause heterogeneity bias.",
       "green"
     ))
+    return(invisible(NULL))
   }
-  invisible(result)
 }
 
 

--- a/R/check_group_variation.R
+++ b/R/check_group_variation.R
@@ -107,7 +107,14 @@
 #'   )
 #' )
 #'
-#' check_group_variation(egsingle, by = c("schoolid", "childid"), include_by = TRUE)
+#' result <- check_group_variation(
+#'   egsingle,
+#'   by = c("schoolid", "childid"),
+#'   include_by = TRUE
+#' )
+#' result
+#'
+#' summary(result)
 #'
 #' @examplesIf insight::check_if_installed("lme4", quietly = TRUE)
 #'
@@ -247,12 +254,12 @@ print_html.check_group_variation <- function(x, ...) {
   caption <- "Check group variation"
 
   if (insight::n_unique(x$group) == 1L) {
-    x$group <- by <- NULL
+    x$group <- group_by <- NULL
   } else {
-    by <- "group"
+    group_by <- "group"
   }
 
-  insight::export_table(x, caption = caption, by = by, format = "html", ...)
+  insight::export_table(x, caption = caption, by = group_by, format = "html", ...)
 }
 
 
@@ -342,9 +349,9 @@ summary.check_group_variation <- function(object, ...) {
     k <- nlevels(f1)
     sm <- methods::as(
       methods::new("ngTMatrix",
-                   i = as.integer(group) - 1L,
-                   j = as.integer(f1) - 1L,
-                   Dim = c(length(levels(group)), k)
+        i = as.integer(group) - 1L,
+        j = as.integer(f1) - 1L,
+        Dim = c(nlevels(group), k)
       ),
       "CsparseMatrix"
     )
@@ -384,5 +391,5 @@ summary.check_group_variation <- function(object, ...) {
     return(c("within", "crossed"))
   }
 
-  return(c("both", "crossed"))
+  c("both", "crossed")
 }

--- a/R/check_group_variation.R
+++ b/R/check_group_variation.R
@@ -3,7 +3,7 @@
 #'
 #' @description
 #' Checks if variables vary within and/or between levels of grouping variables.
-#' This function can be used to infer the hierarchical structure of a given
+#' This function can be used to infer the hierarchical Design of a given
 #' dataset, or detect any predictors that might cause heterogeneity bias (_Bell
 #' and Jones, 2015_). Use `summary()` on the output if you are mainly interested
 #' if and which predictors are possibly affected by heterogeneity bias.
@@ -57,8 +57,9 @@
 #'   when `tolerance_factor = "balanced"` the variable is fully crossed, but not
 #'   perfectly balanced).
 #'
-#' Additionally, non-numeric variables can have a nested or crossed structure
-#' related to the group variables. This is indicated in the column `Structure`.
+#' Additionally, the design of non-numeric variables is also checked to see if
+#' they are nested within the groups or is they are crossed. This is indicated
+#' in the column `Design`.
 #'
 #' ## Heterogeneity bias
 #' Variables that vary both within and between groups can cause a heterogeneity
@@ -67,7 +68,7 @@
 #' for further details. Use `summary()` to get a short text result that indicates
 #' if and which predictors are possibly affected by heterogeneity bias.
 #'
-#' @return A data frame with Group, Variable, Variation and Structure columns.
+#' @return A data frame with Group, Variable, Variation and Design columns.
 #'
 #' @seealso
 #' For further details, read the vignette
@@ -200,11 +201,11 @@ check_group_variation.data.frame <- function(x,
   )
   combinations <- combinations[combinations$Variable != combinations$Group, ]
   combinations$Variation <- NA_character_
-  combinations$Structure <- NA_character_
+  combinations$Design <- NA_character_
 
   # initialize lists
   for (i in seq_len(nrow(combinations))) {
-    combinations[i, c("Variation", "Structure")] <- .check_nested(
+    combinations[i, c("Variation", "Design")] <- .check_nested(
       x,
       combinations[i, "Group"],
       combinations[i, "Variable"],
@@ -288,7 +289,7 @@ summary.check_group_variation <- function(object, ...) {
 #' @keywords internals
 .check_nested <- function(data, by, predictor, ...) {
   if (insight::n_unique(data[[predictor]]) == 1L) {
-    return(c(NA_character_, NA_character_))
+    return(NA_character_)
   }
 
   UseMethod(".check_nested", data[[predictor]])

--- a/R/check_group_variation.R
+++ b/R/check_group_variation.R
@@ -50,14 +50,15 @@
 #' These variables can have one of the following three labels:
 #' - _between_ - the variable is fixed (has exactly one unique, constant value)
 #'   for each group.
-#' - _nested_ - the variable vary within each group, with each group having
-#'   their own set of unique levels of the variable.
 #' - _within_ - the variable is _crossed_ with the grouping variable - each
 #'   value appear within each group. The `tolerance_factor` argument controls if
 #'   full balance is also required.
 #' - _both_ - the variable is partially nested within the grouping variable (or,
 #'   when `tolerance_factor = "balanced"` the variable is fully crossed, but not
 #'   perfectly balanced).
+#'
+#' Additionally, non-numeric variables can have a nested or crossed structure
+#' related to the group variables. This is indicated in the column `Structure`.
 #'
 #' ## Heterogeneity bias
 #' Variables that vary both within and between groups can cause a heterogeneity
@@ -66,7 +67,7 @@
 #' for further details. Use `summary()` to get a short text result that indicates
 #' if and which predictors are possibly affected by heterogeneity bias.
 #'
-#' @return A data frame with group, variable, and type columns.
+#' @return A data frame with Group, Variable, Variation and Structure columns.
 #'
 #' @seealso
 #' For further details, read the vignette

--- a/R/check_group_variation.R
+++ b/R/check_group_variation.R
@@ -255,8 +255,8 @@ print_html.check_group_variation <- function(x, ...) {
 
 
 #' @export
-summary.check_group_variation <- function(x, ...) {
-  result <- unique(x$variable[startsWith(x$type, "both")])
+summary.check_group_variation <- function(object, ...) {
+  result <- unique(object$variable[startsWith(object$type, "both")])
 
   if (length(result)) {
     insight::format_alert(paste(

--- a/R/check_group_variation.R
+++ b/R/check_group_variation.R
@@ -269,15 +269,13 @@ print_html.check_group_variation <- function(x, ...) {
 #' @param object result from `check_group_variation()`
 #' @param flatten Logical, if `TRUE`, the values are returned as character vector, not as list. Duplicated values are removed.
 summary.check_group_variation <- function(object, flatten = FALSE, ...) {
-
   i <- which(object$Variation %in% "both")
 
   if (length(i)) {
-    object <- object[i,,drop = FALSE]
+    object <- object[i, , drop = FALSE]
 
     result <- split(object$Variable, object$Group)
     if (length(result) > 1L) {
-
       txt <- paste0("- ", names(result), ": ", sapply(result, paste0, collapse = ", "), collapse = "\n")
     } else {
       txt <- paste0("- ", paste0(result[[1]], collapse = ", "))
@@ -293,7 +291,6 @@ summary.check_group_variation <- function(object, flatten = FALSE, ...) {
     } else {
       return(invisible(result))
     }
-
   } else {
     insight::format_alert(insight::color_text(
       "No predictor found that could cause heterogeneity bias.",

--- a/R/zzz-deprecated-check_heterogeneity_bias.R
+++ b/R/zzz-deprecated-check_heterogeneity_bias.R
@@ -1,4 +1,4 @@
-#' @title Check model predictor for heterogeneity bias
+#' @title Check model predictor for heterogeneity bias *(Deprecated)*
 #' @name check_heterogeneity_bias
 #'
 #' @description

--- a/man/check_group_variation.Rd
+++ b/man/check_group_variation.Rd
@@ -21,6 +21,8 @@ check_group_variation(x, ...)
   tolerance_factor = "crossed",
   ...
 )
+
+\method{summary}{check_group_variation}(object, flatten = FALSE, ...)
 }
 \arguments{
 \item{x}{A data frame or a mixed model. See details and examples.}
@@ -51,6 +53,10 @@ varying only "within" a grouping variable? Options are:
 \item \code{"balanced"} - if all groups have all unique values of X, \emph{with equal
 frequency}.
 }}
+
+\item{object}{result from \code{check_group_variation()}}
+
+\item{flatten}{Logical, if \code{TRUE}, the values are returned as character vector, not as list. Duplicated values are removed.}
 }
 \value{
 A data frame with Group, Variable, Variation and Design columns.

--- a/man/check_group_variation.Rd
+++ b/man/check_group_variation.Rd
@@ -4,6 +4,7 @@
 \alias{check_group_variation}
 \alias{check_group_variation.default}
 \alias{check_group_variation.data.frame}
+\alias{summary.check_group_variation}
 \title{Check variables for within- and/or between-group variation}
 \usage{
 check_group_variation(x, ...)
@@ -52,11 +53,11 @@ frequency}.
 }}
 }
 \value{
-A data frame with Group, Variable, Variation and Structure columns.
+A data frame with Group, Variable, Variation and Design columns.
 }
 \description{
 Checks if variables vary within and/or between levels of grouping variables.
-This function can be used to infer the hierarchical structure of a given
+This function can be used to infer the hierarchical Design of a given
 dataset, or detect any predictors that might cause heterogeneity bias (\emph{Bell
 and Jones, 2015}). Use \code{summary()} on the output if you are mainly interested
 if and which predictors are possibly affected by heterogeneity bias.
@@ -94,8 +95,9 @@ when \code{tolerance_factor = "balanced"} the variable is fully crossed, but not
 perfectly balanced).
 }
 
-Additionally, non-numeric variables can have a nested or crossed structure
-related to the group variables. This is indicated in the column \code{Structure}.
+Additionally, the design of non-numeric variables is also checked to see if
+they are nested within the groups or is they are crossed. This is indicated
+in the column \code{Design}.
 }
 
 \subsection{Heterogeneity bias}{

--- a/man/check_group_variation.Rd
+++ b/man/check_group_variation.Rd
@@ -52,7 +52,7 @@ frequency}.
 }}
 }
 \value{
-A data frame with group, variable, and type columns.
+A data frame with Group, Variable, Variation and Structure columns.
 }
 \description{
 Checks if variables vary within and/or between levels of grouping variables.
@@ -86,8 +86,6 @@ These variables can have one of the following three labels:
 \itemize{
 \item \emph{between} - the variable is fixed (has exactly one unique, constant value)
 for each group.
-\item \emph{nested} - the variable vary within each group, with each group having
-their own set of unique levels of the variable.
 \item \emph{within} - the variable is \emph{crossed} with the grouping variable - each
 value appear within each group. The \code{tolerance_factor} argument controls if
 full balance is also required.
@@ -95,6 +93,9 @@ full balance is also required.
 when \code{tolerance_factor = "balanced"} the variable is fully crossed, but not
 perfectly balanced).
 }
+
+Additionally, non-numeric variables can have a nested or crossed structure
+related to the group variables. This is indicated in the column \code{Structure}.
 }
 
 \subsection{Heterogeneity bias}{

--- a/man/check_group_variation.Rd
+++ b/man/check_group_variation.Rd
@@ -135,7 +135,14 @@ egsingle <- data.frame(
   )
 )
 
-check_group_variation(egsingle, by = c("schoolid", "childid"), include_by = TRUE)
+result <- check_group_variation(
+  egsingle,
+  by = c("schoolid", "childid"),
+  include_by = TRUE
+)
+result
+
+summary(result)
 
 \dontshow{if (insight::check_if_installed("lme4", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 

--- a/man/check_group_variation.Rd
+++ b/man/check_group_variation.Rd
@@ -86,6 +86,8 @@ These variables can have one of the following three labels:
 \itemize{
 \item \emph{between} - the variable is fixed (has exactly one unique, constant value)
 for each group.
+\item \emph{nested} - the variable vary within each group, with each group having
+their own set of unique levels of the variable.
 \item \emph{within} - the variable is \emph{crossed} with the grouping variable - each
 value appear within each group. The \code{tolerance_factor} argument controls if
 full balance is also required.
@@ -93,10 +95,6 @@ full balance is also required.
 when \code{tolerance_factor = "balanced"} the variable is fully crossed, but not
 perfectly balanced).
 }
-
-Additionally, if variables are nested within the groups (i.e. variables vary
-within each group indicated in \code{by}, with each group having their own set of
-unique levels of the variable), a \emph{nested} label is added,
 }
 
 \subsection{Heterogeneity bias}{

--- a/man/check_heterogeneity_bias.Rd
+++ b/man/check_heterogeneity_bias.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/zzz-deprecated-check_heterogeneity_bias.R
 \name{check_heterogeneity_bias}
 \alias{check_heterogeneity_bias}
-\title{Check model predictor for heterogeneity bias}
+\title{Check model predictor for heterogeneity bias \emph{(Deprecated)}}
 \usage{
 check_heterogeneity_bias(x, select = NULL, by = NULL, nested = FALSE)
 }

--- a/man/check_outliers.Rd
+++ b/man/check_outliers.Rd
@@ -203,7 +203,7 @@ minus a coefficient times the MAD method (Leys et al., 2013).
 \item \strong{Robust Mahalanobis Distance}:
 A robust version of Mahalanobis distance using an Orthogonalized
 Gnanadesikan-Kettenring pairwise estimator (Gnanadesikan and Kettenring,
-1972). Requires the \strong{bigutilsr} package. See the \code{\link[bigutilsr:dist_ogk]{bigutilsr::dist_ogk()}}
+1972). Requires the \strong{bigutilsr} package. See the \code{\link[bigutilsr:covrob_ogk]{bigutilsr::dist_ogk()}}
 function.
 \item \strong{Minimum Covariance Determinant (MCD)}:
 Another robust version of Mahalanobis. Leys et al. (2018) argue that

--- a/man/check_outliers.Rd
+++ b/man/check_outliers.Rd
@@ -203,7 +203,7 @@ minus a coefficient times the MAD method (Leys et al., 2013).
 \item \strong{Robust Mahalanobis Distance}:
 A robust version of Mahalanobis distance using an Orthogonalized
 Gnanadesikan-Kettenring pairwise estimator (Gnanadesikan and Kettenring,
-1972). Requires the \strong{bigutilsr} package. See the \code{\link[bigutilsr:covrob_ogk]{bigutilsr::dist_ogk()}}
+1972). Requires the \strong{bigutilsr} package. See the \code{\link[bigutilsr:dist_ogk]{bigutilsr::dist_ogk()}}
 function.
 \item \strong{Minimum Covariance Determinant (MCD)}:
 Another robust version of Mahalanobis. Leys et al. (2018) argue that

--- a/tests/testthat/test-check_group_variation.R
+++ b/tests/testthat/test-check_group_variation.R
@@ -1,35 +1,25 @@
 test_that("check_group_variation-1", {
-  skip_if_not_installed("lme4")
-  set.seed(11)
+
   group <- rep(LETTERS[1:3], each = 3)
   variable1 <- rep(letters[1:3], each = 3)
+  variable1b <- rep(letters[1:2], times = c(6, 3))
   variable2 <- rep(letters[1:3], times = 3)
   variable3 <- letters[1:9]
   variable4 <- c(letters[1:5], letters[1:4])
 
-  d <- data.frame(group, variable1, variable2, variable3, variable4)
+  d <- data.frame(group, variable1, variable1b, variable2, variable3, variable4)
   out <- check_group_variation(d, by = "group")
 
-  out2 <- c(
-    variable1 = lme4::isNested(variable1, group),
-    variable2 = lme4::isNested(variable2, group),
-    variable3 = lme4::isNested(variable3, group),
-    variable4 = lme4::isNested(variable4, group)
-  )
   expect_equal(
     out,
     data.frame(
-      group = c("group", "group", "group", "group"),
-      variable = c("variable1", "variable2", "variable3", "variable4"),
-      type = c("between (nested)", "within", "both (nested)", "both")
+      group = c("group", "group", "group", "group", "group"),
+      variable = c("variable1", "variable1b", "variable2", "variable3", "variable4"),
+      type = c("between", "between", "within", "nested", "both")
     ),
     ignore_attr = TRUE
   )
-  expect_equal(
-    endsWith(out$type, "(nested)"),
-    out2,
-    ignore_attr = TRUE
-  )
+
 
   set.seed(111)
   dat <- data.frame(
@@ -59,7 +49,7 @@ test_that("check_group_variation-1", {
     data.frame(
       group = c("id", "id", "id", "id", "id", "id"),
       variable = c("between_num", "within_num", "both_num", "between_fac", "within_fac", "both_fac"),
-      type = c("between", "within", "both", "between (nested)", "within", "both")
+      type = c("between", "within", "both", "between", "within", "both")
     ),
     ignore_attr = TRUE
   )
@@ -161,7 +151,7 @@ test_that("check_group_variation, multiple by", {
     data.frame(
       group = c("schoolid", "schoolid", "schoolid", "schoolid", "childid", "childid", "childid", "childid"),
       variable = c("lowinc", "female", "year", "math", "lowinc", "female", "year", "math"),
-      type = c("between (nested)", "both", "within", "both", "between", "between", "within", "both")
+      type = c("between", "both", "within", "both", "between", "between", "within", "both")
     ),
     ignore_attr = TRUE
   )
@@ -179,7 +169,7 @@ test_that("check_group_variation, multiple by", {
         "schoolid", "lowinc", "female", "year", "math"
       ),
       type = c(
-        "both (nested)", "between (nested)", "both", "within", "both",
+        "nested", "between", "both", "within", "both",
         "between", "between", "between", "within", "both"
       )
     ),
@@ -239,10 +229,10 @@ test_that("check_group_variation, numeric_as_factor", {
   )
   expect_identical(
     out1$type,
-    c("between (nested)", "both", "within", "both", "between", "between", "within", "both")
+    c("between", "both", "within", "both", "between", "between", "within", "both")
   )
   expect_identical(
     out2$type,
-    c("between (nested)", "both", "within", "both (nested)", "between", "between", "within", "both")
+    c("between", "both", "within", "nested", "between", "between", "within", "both")
   )
 })

--- a/tests/testthat/test-check_group_variation.R
+++ b/tests/testthat/test-check_group_variation.R
@@ -252,4 +252,3 @@ test_that("check_group_variation, numeric_as_factor", {
     c("nested", NA, "crossed", "nested", NA, NA, "crossed", NA)
   )
 })
-

--- a/tests/testthat/test-check_group_variation.R
+++ b/tests/testthat/test-check_group_variation.R
@@ -1,20 +1,22 @@
 test_that("check_group_variation-1", {
   group <- rep(LETTERS[1:3], each = 3)
+  constant <- "a"
   variable1 <- rep(letters[1:3], each = 3)
   variable1b <- rep(letters[1:2], times = c(6, 3))
   variable2 <- rep(letters[1:3], times = 3)
   variable3 <- letters[1:9]
   variable4 <- c(letters[1:5], letters[1:4])
 
-  d <- data.frame(group, variable1, variable1b, variable2, variable3, variable4)
+  d <- data.frame(group, constant, variable1, variable1b, variable2, variable3, variable4)
   out <- check_group_variation(d, by = "group")
 
   expect_equal(
     out,
     data.frame(
-      group = c("group", "group", "group", "group", "group"),
-      variable = c("variable1", "variable1b", "variable2", "variable3", "variable4"),
-      type = c("between", "between", "within", "nested", "both")
+      Group = rep("group", 6),
+      Variable = c("constant", "variable1", "variable1b", "variable2", "variable3", "variable4"),
+      Variation = c(NA, "between", "between", "within", "both", "both"),
+      Design = c(NA, "nested", NA, "crossed", "nested", NA)
     ),
     ignore_attr = TRUE
   )
@@ -46,9 +48,10 @@ test_that("check_group_variation-1", {
   expect_equal(
     out,
     data.frame(
-      group = c("id", "id", "id", "id", "id", "id"),
-      variable = c("between_num", "within_num", "both_num", "between_fac", "within_fac", "both_fac"),
-      type = c("between", "within", "both", "between", "within", "both")
+      Group = c("id", "id", "id", "id", "id", "id"),
+      Variable = c("between_num", "within_num", "both_num", "between_fac", "within_fac", "both_fac"),
+      Variation = c("between", "within", "both", "between", "within", "both"),
+      Design = c(NA, NA, NA, "nested", "crossed", NA)
     ),
     ignore_attr = TRUE
   )
@@ -67,9 +70,10 @@ test_that("check_group_variation-2", {
   expect_equal(
     out,
     data.frame(
-      group = c("ID", "ID"),
-      variable = c("Sepal.Length", "Petal.Length"),
-      type = c("both", "both")
+      Group = c("ID", "ID"),
+      Variable = c("Sepal.Length", "Petal.Length"),
+      Variation = c("both", "both"),
+      Design = c(NA_character_)
     ),
     ignore_attr = TRUE
   )
@@ -85,9 +89,10 @@ test_that("check_group_variation-2", {
   expect_equal(
     out,
     data.frame(
-      group = c("ID", "ID", "ID", "ID"),
-      variable = c("age", "phq4", "QoL", "education"),
-      type = c("between", "both", "both", "between")
+      Group = c("ID", "ID", "ID", "ID"),
+      Variable = c("age", "phq4", "QoL", "education"),
+      Variation = c("between", "both", "both", "between"),
+      Design = c(NA_character_)
     ),
     ignore_attr = TRUE
   )
@@ -117,9 +122,10 @@ test_that("check_group_variation-2", {
   expect_equal(
     out,
     data.frame(
-      group = c("ID", "ID", "ID", "ID", "ID", "ID"),
-      variable = c("age", "phq4", "QoL", "education", "phq4w", "phq4b"),
-      type = c("between", "both", "both", "between", "within", "between")
+      Group = c("ID", "ID", "ID", "ID", "ID", "ID"),
+      Variable = c("age", "phq4", "QoL", "education", "phq4w", "phq4b"),
+      Variation = c("between", "both", "both", "between", "within", "between"),
+      Design = c(NA_character_)
     ),
     ignore_attr = TRUE
   )
@@ -148,9 +154,10 @@ test_that("check_group_variation, multiple by", {
   expect_equal(
     out,
     data.frame(
-      group = c("schoolid", "schoolid", "schoolid", "schoolid", "childid", "childid", "childid", "childid"),
-      variable = c("lowinc", "female", "year", "math", "lowinc", "female", "year", "math"),
-      type = c("between", "both", "within", "both", "between", "between", "within", "both")
+      Group = c("schoolid", "schoolid", "schoolid", "schoolid", "childid", "childid", "childid", "childid"),
+      Variable = c("lowinc", "female", "year", "math", "lowinc", "female", "year", "math"),
+      Variation = c("between", "both", "within", "both", "between", "between", "within", "both"),
+      Design = c("nested", rep(NA_character_, 7))
     ),
     ignore_attr = TRUE
   )
@@ -159,18 +166,19 @@ test_that("check_group_variation, multiple by", {
   expect_equal(
     out,
     data.frame(
-      group = c(
+      Group = c(
         "schoolid", "schoolid", "schoolid", "schoolid", "schoolid",
         "childid", "childid", "childid", "childid", "childid"
       ),
-      variable = c(
+      Variable = c(
         "childid", "lowinc", "female", "year", "math",
         "schoolid", "lowinc", "female", "year", "math"
       ),
-      type = c(
-        "nested", "between", "both", "within", "both",
+      Variation = c(
+        "both", "between", "both", "within", "both",
         "between", "between", "between", "within", "both"
-      )
+      ),
+      Design = c("nested", "nested", rep(NA_character_, 8))
     ),
     ignore_attr = TRUE
   )
@@ -194,9 +202,10 @@ test_that("check_group_variation, models", {
   expect_equal(
     out,
     data.frame(
-      group = "Subject",
-      variable = "Days",
-      type = "within"
+      Group = "Subject",
+      Variable = "Days",
+      Variation = "within",
+      Design = NA_character_
     ),
     ignore_attr = TRUE
   )
@@ -227,11 +236,20 @@ test_that("check_group_variation, numeric_as_factor", {
     numeric_as_factor = TRUE
   )
   expect_identical(
-    out1$type,
+    out1$Variation,
     c("between", "both", "within", "both", "between", "between", "within", "both")
   )
   expect_identical(
-    out2$type,
-    c("between", "both", "within", "nested", "between", "between", "within", "both")
+    out2$Variation,
+    c("between", "both", "within", "both", "between", "between", "within", "both")
+  )
+  expect_identical(
+    out1$Design,
+    c("nested", NA, NA, NA, NA, NA, NA, NA)
+  )
+  expect_identical(
+    out2$Design,
+    c("nested", NA, "crossed", "nested", NA, NA, "crossed", NA)
   )
 })
+

--- a/tests/testthat/test-check_group_variation.R
+++ b/tests/testthat/test-check_group_variation.R
@@ -1,5 +1,4 @@
 test_that("check_group_variation-1", {
-
   group <- rep(LETTERS[1:3], each = 3)
   variable1 <- rep(letters[1:3], each = 3)
   variable1b <- rep(letters[1:2], times = c(6, 3))


### PR DESCRIPTION
@strengejacke we can keep working here, if you have more thoughts.

We can make two types of distinctions:
- Is variable X nested within groups (every group has a unique set of values of X)
- Is variable X crossed with groups (all groups have all possible values of X)
- (Or other)

But also:
- Does variable X vary between groups (is it correlated with group)
- Does variable X vary within groups
- (Or is correlated and varies within group)

So we have the following combinations (with "--" marking impossible situations):

|                | nested    | crossed  | other |
|----------------|-----------|----------|--------|
| **varies only between** | "between" | --       | "between"     |
| **varies only within**  | --  | "within" | --     |
| **both**           | "nested"        | --   | "both" |

