### PR TITLE
Use Pearson residuals for glmmTMB/MixMod homogeneity panel

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -56,7 +56,11 @@ Authors@R:
       person(given = "Joseph",
              family = "Luchman",
              role = "ctb",
-             comment = c(ORCID = "0000-0002-8886-9717")))
+             comment = c(ORCID = "0000-0002-8886-9717")),
+      person(given = "Julius",
+             family = "Bogomolovas",
+             role = "ctb",
+             comment = c(ORCID = "0000-0001-8344-1909")))
 Maintainer: Daniel Lüdecke <officialeasystats@gmail.com>
 Description: Utilities for computing measures to assess model quality,
     which are not directly provided by R's 'base' or 'stats' packages.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: performance
 Title: Assessment of Regression Models Performance
-Version: 0.17.1.2
+Version: 0.17.1.3
 Authors@R:
     c(person(given = "Daniel",
              family = "Lüdecke",

--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,13 @@
   negative-binomial models (`nbinom1`/`nbinom2`) without random effects, and now
   returns McFadden's R2 for them.
 
+* `check_model()` now uses Pearson residuals for the homogeneity-of-variance
+  plot of `glmmTMB` and `MixMod` models. Previously these residuals were divided
+  by a single scalar, which is only correct when the variance function does not
+  depend on the mean; for non-mixed binomial and Poisson models that scalar was
+  1, so the plot could suggest heteroscedasticity for correctly specified models
+  (#926).
+
 # performance 0.17.1
 
 ## Changes

--- a/R/check_model_diagnostics.R
+++ b/R/check_model_diagnostics.R
@@ -264,11 +264,11 @@
     } else if (inherits(model, "gam")) {
       stats::residuals(model, type = "scaled.pearson")
     } else if (inherits(model, c("glmmTMB", "MixMod"))) {
-      ## Pearson residuals are scaled by the family's variance function
-      ## V(mu_i), which varies across observations. The fallback below
-      ## divides by a single scalar, which is only correct when V() does
-      ## not depend on mu (e.g. gaussian); for binomial and poisson that
-      ## scalar is 1, i.e. no standardization at all.
+      ## Pearson residuals are scaled by the family's variance function V(mu_i),
+      ## which varies across observations. The fallback below divides by a single
+      ## scalar, which is only correct when V() does not depend on mu (e.g.
+      ## gaussian). For non-mixed binomial/poisson models `.sigma_glmmTMB_nonmixed()`
+      ## returns 1, i.e. no standardization at all.
       r_pearson <- .safe(stats::residuals(model, type = "pearson"))
       if (is.null(r_pearson) || all(is.na(r_pearson))) {
         residual_sigma <- if (faminfo$is_mixed) {
@@ -276,7 +276,7 @@
         } else {
           .sigma_glmmTMB_nonmixed(model, faminfo)
         }
-        stats::residuals(model) / residual_sigma
+        stats::residuals(model, type = "response") / residual_sigma
       } else {
         r_pearson
       }

--- a/R/check_model_diagnostics.R
+++ b/R/check_model_diagnostics.R
@@ -264,12 +264,22 @@
     } else if (inherits(model, "gam")) {
       stats::residuals(model, type = "scaled.pearson")
     } else if (inherits(model, c("glmmTMB", "MixMod"))) {
-      residual_sigma <- if (faminfo$is_mixed) {
-        sqrt(insight::get_variance_residual(model))
+      ## Pearson residuals are scaled by the family's variance function
+      ## V(mu_i), which varies across observations. The fallback below
+      ## divides by a single scalar, which is only correct when V() does
+      ## not depend on mu (e.g. gaussian); for binomial and poisson that
+      ## scalar is 1, i.e. no standardization at all.
+      r_pearson <- .safe(stats::residuals(model, type = "pearson"))
+      if (is.null(r_pearson) || all(is.na(r_pearson))) {
+        residual_sigma <- if (faminfo$is_mixed) {
+          sqrt(insight::get_variance_residual(model))
+        } else {
+          .sigma_glmmTMB_nonmixed(model, faminfo)
+        }
+        stats::residuals(model) / residual_sigma
       } else {
-        .sigma_glmmTMB_nonmixed(model, faminfo)
+        r_pearson
       }
-      stats::residuals(model) / residual_sigma
     } else if (inherits(model, "glm")) {
       ## TODO: check if we can / should use deviance residuals (as for QQ plots) here as well?
       stats::rstandard(model, type = "pearson")


### PR DESCRIPTION
<p>Closes issue #926.</p>
<h2>The problem</h2>
<p><code>.model_diagnostic_homogeneity()</code> branches by class. The <code>glm</code> branch uses
<code>rstandard(type = "pearson")</code>, which divides each residual by
<code>sqrt(V(mu_i) * phi * (1 - h_ii))</code>. The <code>glmmTMB</code>/<code>MixMod</code> branch instead
divides by a single scalar:</p>
<pre><code class="language-r">stats::residuals(model) / residual_sigma
</code></pre>
<p><code>residuals.glmmTMB()</code> defaults to <code>type = "response"</code>, and <code>residual_sigma</code> is
one number for the whole model. That is only correct when <code>V()</code> does not depend
on <code>mu</code>. For non-mixed fits <code>.sigma_glmmTMB_nonmixed()</code> returns <code>1</code> outright for
<code>binomial</code>, <code>poisson</code> and <code>truncated_poisson</code>, so no standardization happens at
all and the panel plots <code>sqrt(|raw response residuals|)</code>.</p>
<p>Since binomial spread is proportional to <code>sqrt(p(1-p))</code> and the panel plots
<code>sqrt(|r_i|)</code>, the smooth follows <code>V(mu_i)^(1/4)</code> and must bow near p = 0.5
however well specified the model is.</p>
<p>This also differs from what <code>?check_model</code> documents under <em>Residuals for
(Generalized) Linear Models</em>, which says these plots use standardized Pearson's
residuals for generalized linear models.</p>
<h2>Scope: not just binomial</h2>
<p>Implied per-observation SD (<code>residuals(type="response") / residuals(type="pearson")</code>)
across families, glmmTMB 1.1.15:</p>

family | implied SD | affected
-- | -- | --
gaussian | constant [1, 1] | no
t_family | constant | no
binomial | varies | yes
betabinomial | varies | yes
poisson | varies | yes
nbinom1 | [0.99, 2.00] | yes
nbinom2 | varies | yes
Gamma | [1.02, 2.19] | yes
beta | [0.119, 0.154] | yes
ordbeta | [0.388, 0.500] | yes
tweedie | [0.766, 1.60] | yes
genpois | [0.991, 2.01] | yes
compois | [0.969, 2.02] | yes
truncated_poisson | [1.05, 1.86] | yes
gaussian + dispformula | [0.966, 1.07] | yes
poisson/nbinom2 + ZI | varies | yes


<p>No family errored, so the fallback added here is protection for future or exotic
families rather than a workaround for current failures.</p>
<h2>The change</h2>
<p>Try <code>residuals(type = "pearson")</code> first; keep the existing expression as a
fallback when glmmTMB cannot compute them. <code>.safe()</code> catches errors, and the
<code>all(is.na())</code> guard avoids a silently blank panel.</p>
<p>Delegating rather than computing <code>V(mu)</code> here keeps per-family variance
knowledge in one place. <code>performance</code> already maintains <code>.expected_variance()</code>
for <code>check_overdispersion()</code>, and <code>see</code> carries a duplicate of this same
homogeneity branch, so a per-family table here would be the third copy.</p>
<h2>Effect</h2>
<p>Ratio of max to min of the panel's loess smooth (1 = flat), n = 600, size = 20,
fitted probabilities spanning about 0.03 to 0.95:</p>
<pre><code>                        before   after
glm binomial              1.04    1.04
glmmTMB binomial          1.57    1.04
glmmTMB combinomial       1.57    1.04
</code></pre>
<p>The <code>glm</code> column is the control and does not move. Both glmmTMB columns flatten
to the same value, and the flat level sits near 0.85, close to
E sqrt|Z| = 0.822 for a standard normal, i.e. the residuals are now scaled to
unit variance rather than merely looking flat.</p>
<p>The third column is a Conway-Maxwell-Binomial family from a pending glmmTMB PR.
It is included because it makes the delegation argument concretely: the panel
comes out correct for a family <code>performance</code> has never heard of, with no changes
here.</p>
<img width="1500" height="1000" alt="homogeneity_before_after" src="https://github.com/user-attachments/assets/8dbb9b67-66f8-46be-b3e3-5bcb67804120" />
<h2>Two things to flag</h2>
<p><strong>gaussian.</strong> This is the one family the current code gets right: <code>betadisp</code> is
sigma and gaussian variance does not depend on mu, so a constant divisor is
correct. glmmTMB deliberately returns Pearson residuals unscaled by sigma for
fixed-dispersion and constant-<code>dispformula</code> cases, for base R compatibility. So
after this change gaussian glmmTMB panels lose the sigma division. Panel <em>shape</em>
is unaffected, but the y-scale no longer matches the <code>glm</code> branch. Restoring
parity would mean multiplying by <code>sigma(model)</code> in exactly the case glmmTMB
omits it, which reintroduces family-specific logic. Happy to add it if you would
rather have the parity.</p>
<p><strong>beta-binomial with non-constant <code>dispformula</code>.</strong> glmmTMB documents that
beta-binomial Pearson residuals are not scaled by the dispersion factor, because
that factor needs the number of trials. With constant dispersion this is a
constant multiplier and panel shape is fine; with <code>dispformula = ~x</code> the factor
varies and some curvature would remain. Upstream limitation, not introduced
here.</p>
<h2>Related</h2>
<p><code>see::plot.see_check_heteroscedasticity()</code> contains a copy of this branch, so
<code>plot(check_heteroscedasticity(m))</code> is affected the same way. Happy to open the
matching PR there if useful.</p>
<p>Separately, that copy reads <code>model$fit$par["betad"]</code> while glmmTMB renamed the
parameter to <code>betadisp</code> (glmmTMB commit 472ccbe0). <code>[</code> does not partial-match,
so the divisor is <code>NA</code> and the panel comes out all-NA with no error for the
<code>tryCatch</code> to catch. That affects gaussian and Gamma glmmTMB fits. Filing
separately.</p>
<h2>Notes</h2>
<ul>
<li>No test added yet, tell me where you would want one and I will add it.</li>
<li>Reproducible example and the family table script available if useful.</li>
</ul></body></html>