### PR TITLE
correlation for `check_group_variation()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: performance
 Title: Assessment of Regression Models Performance
-Version: 0.17.1.6
+Version: 0.17.1.7
 Authors@R:
     c(person(given = "Daniel",
              family = "Lüdecke",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -103,6 +103,7 @@ Suggests:
     dbscan,
     DHARMa (>= 0.4.7),
     discovr,
+    effectsize,
     estimatr,
     fixest,
     flextable,

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,9 @@
 
 ## Changes
 
+* `check_group_variation()` now returns a numeric effect size of the grouping
+  variable's predictive association strength.
+
 * Updated test-files to fix deprecated names.
 
 * `r2()` now also covers remaining families from package *glmmTMB* and defaults

--- a/R/check_group_variation.R
+++ b/R/check_group_variation.R
@@ -73,12 +73,14 @@
 #' indicates if and which predictors are possibly affected by heterogeneity
 #' bias.
 #'
-#' @return A data frame with Group, Variable, Variation, Design, and Eta columns.
-#'   Eta is an effect size of the grouping variable's predictive association strength:
+#' @return A data frame with Group, Variable, Variation, Design, and r columns.
+#'   `r` is a correlation coefficient representing the grouping variable's predictive association strength:
 #'   when it is 0 the grouping variable carries no predictive information (`"within"`),
 #'   and when it is 1 the variable is perfectly predicted by the grouping variable (`"between"`).
-#'     - For numeric variables it is the square-root of the inter class correlation (ICC)
+#'     - For numeric variables it is the square-root of the inter class correlation (ICC), aka the correlation ratio \eqn{\eta} (Ayres, 1920).
 #'     - For non-numeric variables it is a non-symmetric Cramer's _V_ (when `{effectsize}` is available)
+#'
+#' @references Ayres, L. P. (1920). The correlation ratio. The Journal of Educational Research, 2(1), 452-456.
 #'
 #' @seealso
 #' For further details, read the vignette
@@ -221,11 +223,11 @@ check_group_variation.data.frame <- function(
   combinations <- combinations[combinations$Variable != combinations$Group, ]
   combinations$Variation <- NA_character_
   combinations$Design <- NA_character_
-  combinations$Eta <- NA_real_
+  combinations$r <- NA_real_
 
   # initialize lists
   for (i in seq_len(nrow(combinations))) {
-    combinations[i, c("Variation", "Design", "Eta")] <- .check_nested(
+    combinations[i, c("Variation", "Design", "r")] <- .check_nested(
       x,
       combinations[i, "Group"],
       combinations[i, "Variable"],
@@ -249,8 +251,8 @@ check_group_variation.data.frame <- function(
 #' @export
 print.check_group_variation <- function(x, digits = 3, zap_small = TRUE, ...) {
   x_orig <- x
-  x$Eta <- insight::format_value(
-    x$Eta,
+  x$r <- insight::format_value(
+    x$r,
     digits = digits,
     zap_small = zap_small,
     lead_zero = FALSE
@@ -286,8 +288,8 @@ print_html.check_group_variation <- function(x, digits = 3, zap_small = TRUE, ..
     group_by <- "group"
   }
 
-  x$Eta <- insight::format_value(
-    x$Eta,
+  x$r <- insight::format_value(
+    x$r,
     digits = digits,
     zap_small = zap_small,
     lead_zero = FALSE

--- a/R/check_group_variation.R
+++ b/R/check_group_variation.R
@@ -74,7 +74,7 @@
 #' bias.
 #'
 #' @return A data frame with Group, Variable, Variation, Design, and Eta columns.
-#'   Eta is the correlation coefficient:
+#'   Eta is an effect size of the grouping variable's predictive association strength.
 #'     - For numeric variables it is the square-root of the inter class correlation (ICC)
 #'     - For non-numeric variables it is a non-symmetric Cramer's _V_ (when `{effectsize}` is available)
 #'

--- a/R/check_group_variation.R
+++ b/R/check_group_variation.R
@@ -74,7 +74,9 @@
 #' bias.
 #'
 #' @return A data frame with Group, Variable, Variation, Design, and Eta columns.
-#'   Eta is an effect size of the grouping variable's predictive association strength.
+#'   Eta is an effect size of the grouping variable's predictive association strength:
+#'   when it is 0 the grouping variable carries no predictive information (`"within"`),
+#'   and when it is 1 the variable is perfectly predicted by the grouping variable (`"between"`).
 #'     - For numeric variables it is the square-root of the inter class correlation (ICC)
 #'     - For non-numeric variables it is a non-symmetric Cramer's _V_ (when `{effectsize}` is available)
 #'

--- a/R/check_group_variation.R
+++ b/R/check_group_variation.R
@@ -73,7 +73,10 @@
 #' indicates if and which predictors are possibly affected by heterogeneity
 #' bias.
 #'
-#' @return A data frame with Group, Variable, Variation and Design columns.
+#' @return A data frame with Group, Variable, Variation, Design, and Eta columns.
+#'   Eta is the correlation coefficient:
+#'     - For numeric variables it is the square-root of the inter class correlation (ICC)
+#'     - For non-numeric variables it is a non-symmetric Cramer's _V_ (when `{effectsize}` is available)
 #'
 #' @seealso
 #' For further details, read the vignette
@@ -216,10 +219,11 @@ check_group_variation.data.frame <- function(
   combinations <- combinations[combinations$Variable != combinations$Group, ]
   combinations$Variation <- NA_character_
   combinations$Design <- NA_character_
+  combinations$Eta <- NA_real_
 
   # initialize lists
   for (i in seq_len(nrow(combinations))) {
-    combinations[i, c("Variation", "Design")] <- .check_nested(
+    combinations[i, c("Variation", "Design", "Eta")] <- .check_nested(
       x,
       combinations[i, "Group"],
       combinations[i, "Variable"],
@@ -241,8 +245,14 @@ check_group_variation.data.frame <- function(
 # methods -------------------------------------------------------------
 
 #' @export
-print.check_group_variation <- function(x, ...) {
+print.check_group_variation <- function(x, digits = 3, zap_small = TRUE, ...) {
   x_orig <- x
+  x$Eta <- insight::format_value(
+    x$Eta,
+    digits = digits,
+    zap_small = zap_small,
+    lead_zero = FALSE
+  )
 
   if (insight::n_unique(x$Group) == 1L) {
     x$Group <- NULL
@@ -264,7 +274,7 @@ print.check_group_variation <- function(x, ...) {
 
 
 #' @export
-print_html.check_group_variation <- function(x, ...) {
+print_html.check_group_variation <- function(x, digits = 3, zap_small = TRUE, ...) {
   x_orig <- x
   caption <- "Check group variation"
 
@@ -273,6 +283,13 @@ print_html.check_group_variation <- function(x, ...) {
   } else {
     group_by <- "group"
   }
+
+  x$Eta <- insight::format_value(
+    x$Eta,
+    digits = digits,
+    zap_small = zap_small,
+    lead_zero = FALSE
+  )
 
   insight::export_table(
     x,
@@ -332,7 +349,7 @@ summary.check_group_variation <- function(object, flatten = FALSE, ...) {
 #' @keywords internals
 .check_nested <- function(data, by, predictor, ...) {
   if (insight::n_unique(data[[predictor]]) == 1L) {
-    return(NA_character_)
+    return(list(NA_character_, NA_character_, NA_real_))
   }
 
   UseMethod(".check_nested", data[[predictor]])
@@ -356,22 +373,24 @@ summary.check_group_variation <- function(object, flatten = FALSE, ...) {
   var_between <- stats::var(d[[between_name]], na.rm = TRUE)
   var_within <- stats::var(d[[within_name]], na.rm = TRUE)
   icc <- var_between / (var_between + var_within)
+  eta <- sqrt(icc)
 
   is_between <- icc > tolerance_numeric
   is_within <- (1 - icc) > tolerance_numeric
   is_both <- is_between && is_within
 
   if (is_both) {
-    return(c("both", NA_character_))
+    return(list("both", NA_character_, eta))
   }
   if (is_between) {
-    return(c("between", NA_character_))
+    return(list("between", NA_character_, eta))
   }
   if (is_within) {
-    return(c("within", NA_character_))
+    return(list("within", NA_character_, eta))
   }
 
-  NA_character_
+  # fallback, if none of the above is true, return NA
+  list(NA_character_, NA_character_, eta)
 }
 
 #' @keywords internals
@@ -393,6 +412,24 @@ summary.check_group_variation <- function(object, flatten = FALSE, ...) {
   complete <- stats::complete.cases(group, variable)
   group <- droplevels(as.factor(group[complete]))
   variable <- variable[complete]
+
+  # Effect size
+  tab <- table(variable, group)
+  if (
+    insight::check_if_installed(
+      "effectsize",
+      reason = "for calculating effect sizes",
+      stop = FALSE
+    )
+  ) {
+    if (nrow(tab) < ncol(tab)) {
+      es <- effectsize::cramers_v(tab, ci = NULL, adjust = FALSE)[[1]]
+    } else {
+      es <- effectsize::tschuprows_t(tab, ci = NULL, adjust = FALSE)[[1]]
+    }
+  } else {
+    es <- NA_real_
+  }
 
   struct <- NA_character_
 
@@ -419,32 +456,31 @@ summary.check_group_variation <- function(object, flatten = FALSE, ...) {
   n_uniques <- tapply(variable, group, insight::n_unique)
   is_between <- all(n_uniques == 1L)
   if (is_between) {
-    return(c("between", struct))
+    return(list("between", struct, es))
   }
 
   # If each group has a different number of unique values,
   # then it is partially nested/crossed.
   if (!insight::has_single_value(n_uniques)) {
-    return(c("both", struct))
+    return(list("both", struct, es))
   }
 
   # Is the variable crossed?
   variable_levels <- unique(variable)
   has_all <- tapply(variable, group, function(v) all(variable_levels %in% v))
   if (!all(has_all)) {
-    return(c("both", struct))
+    return(list("both", struct, es))
   }
 
   if (tolerance_factor == "crossed") {
-    return(c("within", "crossed"))
+    return(list("within", "crossed", es))
   }
 
   # Is the variable crossed and balanced?
-  tab <- table(variable, group)
   is_balanced <- all(apply(tab, 2, insight::has_single_value))
   if (is_balanced) {
-    return(c("within", "crossed"))
+    return(list("within", "crossed", es))
   }
 
-  c("both", "crossed")
+  list("both", "crossed", es)
 }

--- a/man/check_group_variation.Rd
+++ b/man/check_group_variation.Rd
@@ -58,7 +58,10 @@ frequency}.
 \item{flatten}{Logical, if \code{TRUE}, the values are returned as character vector, not as list. Duplicated values are removed.}
 }
 \value{
-A data frame with Group, Variable, Variation and Design columns.
+A data frame with Group, Variable, Variation, Design, and Eta columns.
+Eta is the correlation coefficient:
+- For numeric variables it is the square-root of the inter class correlation (ICC)
+- For non-numeric variables it is a non-symmetric Cramer's \emph{V} (when \code{{effectsize}} is available)
 }
 \description{
 Checks if variables vary within and/or between levels of grouping variables.

--- a/man/check_group_variation.Rd
+++ b/man/check_group_variation.Rd
@@ -59,7 +59,7 @@ frequency}.
 }
 \value{
 A data frame with Group, Variable, Variation, Design, and Eta columns.
-Eta is the correlation coefficient:
+Eta is an effect size of the grouping variable's predictive association strength.
 - For numeric variables it is the square-root of the inter class correlation (ICC)
 - For non-numeric variables it is a non-symmetric Cramer's \emph{V} (when \code{{effectsize}} is available)
 }

--- a/man/check_group_variation.Rd
+++ b/man/check_group_variation.Rd
@@ -58,11 +58,11 @@ frequency}.
 \item{flatten}{Logical, if \code{TRUE}, the values are returned as character vector, not as list. Duplicated values are removed.}
 }
 \value{
-A data frame with Group, Variable, Variation, Design, and Eta columns.
-Eta is an effect size of the grouping variable's predictive association strength:
+A data frame with Group, Variable, Variation, Design, and r columns.
+\code{r} is a correlation coefficient representing the grouping variable's predictive association strength:
 when it is 0 the grouping variable carries no predictive information (\code{"within"}),
 and when it is 1 the variable is perfectly predicted by the grouping variable (\code{"between"}).
-- For numeric variables it is the square-root of the inter class correlation (ICC)
+- For numeric variables it is the square-root of the inter class correlation (ICC), aka the correlation ratio \eqn{\eta} (Ayres, 1920).
 - For non-numeric variables it is a non-symmetric Cramer's \emph{V} (when \code{{effectsize}} is available)
 }
 \description{
@@ -176,6 +176,8 @@ summary(result)
 \dontshow{\}) # examplesIf}
 }
 \references{
+Ayres, L. P. (1920). The correlation ratio. The Journal of Educational Research, 2(1), 452-456.
+
 \itemize{
 \item Bell A, Jones K. 2015. Explaining Fixed Effects: Random Effects
 Modeling of Time-Series Cross-Sectional and Panel Data. Political Science

--- a/man/check_group_variation.Rd
+++ b/man/check_group_variation.Rd
@@ -59,7 +59,9 @@ frequency}.
 }
 \value{
 A data frame with Group, Variable, Variation, Design, and Eta columns.
-Eta is an effect size of the grouping variable's predictive association strength.
+Eta is an effect size of the grouping variable's predictive association strength:
+when it is 0 the grouping variable carries no predictive information (\code{"within"}),
+and when it is 1 the variable is perfectly predicted by the grouping variable (\code{"between"}).
 - For numeric variables it is the square-root of the inter class correlation (ICC)
 - For non-numeric variables it is a non-symmetric Cramer's \emph{V} (when \code{{effectsize}} is available)
 }

--- a/tests/testthat/test-check_group_variation.R
+++ b/tests/testthat/test-check_group_variation.R
@@ -29,11 +29,11 @@ test_that("check_group_variation-1", {
     ignore_attr = TRUE
   )
 
-  expect_identical(out1$Eta[out1$Variation %in% "between"], c(1, 1))
-  expect_identical(out1$Eta[out1$Variation %in% "within"], 0)
-  expect_false(any(out1$Eta[!out1$Variation %in% c("between", "within")] %in% c(1, 0)))
-  expect_identical(out1$Eta[1:4], c(NA, 1, 1, 0))
-  expect_true(all(0.45 < out1$Eta[5:6] & out1$Eta[5:6] < 0.75))
+  expect_identical(out1$r[out1$Variation %in% "between"], c(1, 1))
+  expect_identical(out1$r[out1$Variation %in% "within"], 0)
+  expect_false(any(out1$r[!out1$Variation %in% c("between", "within")] %in% c(1, 0)))
+  expect_identical(out1$r[1:4], c(NA, 1, 1, 0))
+  expect_true(all(0.45 < out1$r[5:6] & out1$r[5:6] < 0.75))
 
   set.seed(111)
   dat2 <- data.frame(
@@ -76,11 +76,11 @@ test_that("check_group_variation-1", {
     ignore_attr = TRUE
   )
 
-  expect_identical(out2$Eta[out2$Variation %in% "between"], c(1, 1))
-  expect_identical(out2$Eta[out2$Variation %in% "within"], c(0, 0))
-  expect_false(any(out2$Eta[!out2$Variation %in% c("between", "within")] %in% c(1, 0)))
-  expect_identical(out2$Eta[-c(3, 6)], c(1, 0, 1, 0))
-  expect_true(all(0.7 < out2$Eta[c(3, 6)] & out2$Eta[c(3, 6)] < 0.8))
+  expect_identical(out2$r[out2$Variation %in% "between"], c(1, 1))
+  expect_identical(out2$r[out2$Variation %in% "within"], c(0, 0))
+  expect_false(any(out2$r[!out2$Variation %in% c("between", "within")] %in% c(1, 0)))
+  expect_identical(out2$r[-c(3, 6)], c(1, 0, 1, 0))
+  expect_true(all(0.7 < out2$r[c(3, 6)] & out2$r[c(3, 6)] < 0.8))
 })
 
 
@@ -104,12 +104,12 @@ test_that("check_group_variation-2", {
     ignore_attr = TRUE
   )
   expect_equal(
-    out3$Eta[1],
+    out3$r[1],
     sqrt(r2(lm(Sepal.Length ~ factor(ID), data = iris))[[1]]),
     ignore_attr = TRUE
   )
   expect_equal(
-    out3$Eta[2],
+    out3$r[2],
     sqrt(r2(lm(Petal.Length ~ factor(ID), data = iris))[[1]]),
     ignore_attr = TRUE
   )
@@ -164,11 +164,11 @@ test_that("check_group_variation-2", {
     ignore_attr = TRUE
   )
 
-  expect_identical(out6$Eta[out6$Variation %in% "between"], c(1, 1, 1))
-  expect_equal(out6$Eta[out6$Variation %in% "within"], 0)
-  expect_false(any(out6$Eta[!out6$Variation %in% c("between", "within")] %in% c(1, 0)))
-  expect_equal(out6$Eta[-(2:3)], c(1, 1, 0, 1))
-  expect_true(all(0.8 < out6$Eta[2:3] & out6$Eta[2:3] < 0.85))
+  expect_identical(out6$r[out6$Variation %in% "between"], c(1, 1, 1))
+  expect_equal(out6$r[out6$Variation %in% "within"], 0)
+  expect_false(any(out6$r[!out6$Variation %in% c("between", "within")] %in% c(1, 0)))
+  expect_equal(out6$r[-(2:3)], c(1, 1, 0, 1))
+  expect_true(all(0.8 < out6$r[2:3] & out6$r[2:3] < 0.85))
 })
 
 
@@ -218,11 +218,11 @@ test_that("check_group_variation, multiple by", {
     ),
     ignore_attr = TRUE
   )
-  expect_identical(out7$Eta[out7$Variation %in% "between"], c(1, 1, 1))
-  expect_identical(out7$Eta[out7$Variation %in% "within"], c(0, 0))
-  expect_false(any(out7$Eta[!out7$Variation %in% c("between", "within")] %in% c(1, 0)))
-  expect_identical(out7$Eta[-c(2, 4, 8)], c(1, 0, 1, 1, 0))
-  expect_true(all(0.25 < out7$Eta[c(2, 4, 8)] & out7$Eta[c(2, 4, 8)] < 0.6))
+  expect_identical(out7$r[out7$Variation %in% "between"], c(1, 1, 1))
+  expect_identical(out7$r[out7$Variation %in% "within"], c(0, 0))
+  expect_false(any(out7$r[!out7$Variation %in% c("between", "within")] %in% c(1, 0)))
+  expect_identical(out7$r[-c(2, 4, 8)], c(1, 0, 1, 1, 0))
+  expect_true(all(0.25 < out7$r[c(2, 4, 8)] & out7$r[c(2, 4, 8)] < 0.6))
 
   out8 <- check_group_variation(
     egsingle,
@@ -261,11 +261,11 @@ test_that("check_group_variation, multiple by", {
     ),
     ignore_attr = TRUE
   )
-  expect_identical(out8$Eta[out8$Variation %in% "between"], c(1, 1, 1, 1))
-  expect_identical(out8$Eta[out8$Variation %in% "within"], c(0, 0))
-  expect_false(any(out8$Eta[!out8$Variation %in% c("between", "within")] %in% c(1, 0)))
-  expect_identical(out8$Eta[-c(1, 3, 5, 10)], c(1, 0, 1, 1, 1, 0))
-  expect_true(all(0.25 < out8$Eta[c(1, 3, 5, 10)] & out8$Eta[c(1, 3, 5, 10)] < 0.8))
+  expect_identical(out8$r[out8$Variation %in% "between"], c(1, 1, 1, 1))
+  expect_identical(out8$r[out8$Variation %in% "within"], c(0, 0))
+  expect_false(any(out8$r[!out8$Variation %in% c("between", "within")] %in% c(1, 0)))
+  expect_identical(out8$r[-c(1, 3, 5, 10)], c(1, 0, 1, 1, 1, 0))
+  expect_true(all(0.25 < out8$r[c(1, 3, 5, 10)] & out8$r[c(1, 3, 5, 10)] < 0.8))
 })
 
 
@@ -290,7 +290,7 @@ test_that("check_group_variation, models", {
       Variable = "Days",
       Variation = "within",
       Design = NA_character_,
-      Eta = 0
+      r = 0
     ),
     ignore_attr = TRUE
   )

--- a/tests/testthat/test-check_group_variation.R
+++ b/tests/testthat/test-check_group_variation.R
@@ -1,19 +1,19 @@
 test_that("check_group_variation-1", {
-  group <- rep(LETTERS[1:3], each = 3)
-  constant <- "a"
-  variable1 <- rep(letters[1:3], each = 3)
-  variable1b <- rep(letters[1:2], times = c(6, 3))
-  variable2 <- rep(letters[1:3], times = 3)
-  variable3 <- letters[1:9]
-  variable4 <- c(letters[1:5], letters[1:4])
-
-  d <- data.frame(group, constant, variable1, variable1b, variable2, variable3, variable4)
-  out <- check_group_variation(d, by = "group")
+  dat1 <- data.frame(
+    group = rep(LETTERS[1:3], each = 3),
+    constant = "a",
+    variable1 = rep(letters[1:3], each = 3),
+    variable1b = rep(letters[1:2], times = c(6, 3)),
+    variable2 = rep(letters[1:3], times = 3),
+    variable3 = letters[1:9],
+    variable4 = c(letters[1:5], letters[1:4])
+  )
+  out1 <- check_group_variation(dat1, by = "group")
 
   expect_equal(
-    out,
+    out1[, c("Group", "Variable", "Variation", "Design")],
     data.frame(
-      Group = rep("group", 6),
+      Group = "group",
       Variable = c(
         "constant",
         "variable1",
@@ -23,13 +23,17 @@ test_that("check_group_variation-1", {
         "variable4"
       ),
       Variation = c(NA, "between", "between", "within", "both", "both"),
-      Design = c(NA, "nested", NA, "crossed", "nested", NA)
+      Design = c(NA, "nested", NA, "crossed", "nested", NA),
+      stringsAsFactors = FALSE
     ),
     ignore_attr = TRUE
   )
 
+  expect_identical(out1$Eta[1:4], c(NA, 1, 1, 0))
+  expect_true(all(0.45 < out1$Eta[5:6] & out1$Eta[5:6] < 0.75))
+
   set.seed(111)
-  dat <- data.frame(
+  dat2 <- data.frame(
     id = rep(letters, each = 2),
     between_num = rep(rnorm(26), each = 2),
     within_num = rep(rnorm(2), times = 26),
@@ -38,9 +42,8 @@ test_that("check_group_variation-1", {
     within_fac = rep(LETTERS[1:2], times = 26),
     both_fac = sample(LETTERS[1:5], size = 52, replace = TRUE)
   )
-
-  out <- check_group_variation(
-    dat,
+  out2 <- check_group_variation(
+    dat2,
     select = c(
       "between_num",
       "within_num",
@@ -52,9 +55,9 @@ test_that("check_group_variation-1", {
     by = "id"
   )
   expect_equal(
-    out,
+    out2[, c("Group", "Variable", "Variation", "Design")],
     data.frame(
-      Group = c("id", "id", "id", "id", "id", "id"),
+      Group = "id",
       Variable = c(
         "between_num",
         "within_num",
@@ -64,10 +67,14 @@ test_that("check_group_variation-1", {
         "both_fac"
       ),
       Variation = c("between", "within", "both", "between", "within", "both"),
-      Design = c(NA, NA, NA, "nested", "crossed", NA)
+      Design = c(NA, NA, NA, "nested", "crossed", NA),
+      stringsAsFactors = FALSE
     ),
     ignore_attr = TRUE
   )
+
+  expect_identical(out2$Eta[-c(3, 6)], c(1, 0, 1, 0))
+  expect_true(all(0.7 < out2$Eta[c(3, 6)] & out2$Eta[c(3, 6)] < 0.8))
 })
 
 
@@ -75,13 +82,13 @@ test_that("check_group_variation-2", {
   data(iris)
   set.seed(123)
   iris$ID <- sample.int(4, nrow(iris), replace = TRUE) # fake-ID
-  out <- check_group_variation(
+  out3 <- check_group_variation(
     iris,
     select = c("Sepal.Length", "Petal.Length"),
     by = "ID"
   )
   expect_equal(
-    out,
+    out3[, c("Group", "Variable", "Variation", "Design")],
     data.frame(
       Group = c("ID", "ID"),
       Variable = c("Sepal.Length", "Petal.Length"),
@@ -90,58 +97,68 @@ test_that("check_group_variation-2", {
     ),
     ignore_attr = TRUE
   )
+  expect_equal(
+    out3$Eta[1],
+    sqrt(r2(lm(Sepal.Length ~ factor(ID), data = iris))[[1]]),
+    ignore_attr = TRUE
+  )
+  expect_equal(
+    out3$Eta[2],
+    sqrt(r2(lm(Petal.Length ~ factor(ID), data = iris))[[1]]),
+    ignore_attr = TRUE
+  )
 
   skip_if_not_installed("parameters")
   data(qol_cancer, package = "parameters")
-  d <- qol_cancer
-  out <- check_group_variation(
-    d,
+  out4 <- check_group_variation(
+    qol_cancer,
     select = c("age", "phq4", "QoL", "education"),
     by = "ID"
   )
   expect_equal(
-    out,
+    out4[, c("Group", "Variable", "Variation", "Design")],
     data.frame(
       Group = c("ID", "ID", "ID", "ID"),
       Variable = c("age", "phq4", "QoL", "education"),
       Variation = c("between", "both", "both", "between"),
-      Design = c(NA_character_)
+      Design = c(NA_character_),
+      stringsAsFactors = FALSE
     ),
     ignore_attr = TRUE
   )
 
-  d <- qol_cancer
-  d <- datawizard::demean(d, select = "phq4", by = "ID")
+  dat5 <- datawizard::demean(qol_cancer, select = "phq4", by = "ID")
   expect_error(
     check_group_variation(
-      d,
+      dat5,
       select = c("phq4", "phq4_within", "phq4_between"),
       by = "ID"
     ),
     regex = "One or more"
   )
 
-  d <- qol_cancer
-  d <- datawizard::demean(d, select = "phq4", by = "ID")
-  d <- datawizard::data_rename(
-    d,
+  dat6 <- datawizard::data_rename(
+    dat5,
     select = c(phq4w = "phq4_within", phq4b = "phq4_between")
   )
-  out <- check_group_variation(
-    d,
+  out6 <- check_group_variation(
+    dat6,
     select = c("age", "phq4", "QoL", "education", "phq4w", "phq4b"),
     by = "ID"
   )
   expect_equal(
-    out,
+    out6[, c("Group", "Variable", "Variation", "Design")],
     data.frame(
       Group = c("ID", "ID", "ID", "ID", "ID", "ID"),
       Variable = c("age", "phq4", "QoL", "education", "phq4w", "phq4b"),
       Variation = c("between", "both", "both", "between", "within", "between"),
-      Design = c(NA_character_)
+      Design = c(NA_character_),
+      stringsAsFactors = FALSE
     ),
     ignore_attr = TRUE
   )
+  expect_equal(out6$Eta[-(2:3)], c(1, 1, 0, 1))
+  expect_true(all(0.8 < out6$Eta[2:3] & out6$Eta[2:3] < 0.85))
 })
 
 
@@ -155,48 +172,18 @@ test_that("check_group_variation, multiple by", {
     )),
     female = rep(c(TRUE, FALSE), each = 12),
     year = rep(1:6, times = 4),
-    math = c(
-      -3.068,
-      -1.13,
-      -0.921,
-      0.463,
-      0.021,
-      2.035,
-      -2.732,
-      -2.097,
-      -0.988,
-      0.227,
-      0.403,
-      1.623,
-      -2.732,
-      -1.898,
-      -0.921,
-      0.587,
-      1.578,
-      2.3,
-      -2.288,
-      -2.162,
-      -1.631,
-      -1.555,
-      -0.725,
-      0.097
-    )
+    # fmt: skip
+    math = c(-3.068, -1.13, -0.921, 0.463, 0.021, 2.035, -2.732, -2.097,
+             -0.988, 0.227, 0.403, 1.623, -2.732, -1.898, -0.921, 0.587,
+             1.578, 2.3, -2.288, -2.162, -1.631, -1.555, -0.725, 0.097),
+    stringsAsFactors = FALSE
   )
 
-  out <- check_group_variation(egsingle, by = c("schoolid", "childid"))
+  out7 <- check_group_variation(egsingle, by = c("schoolid", "childid"))
   expect_equal(
-    out,
+    out7[, c("Group", "Variable", "Variation", "Design")],
     data.frame(
-      Group = c(
-        "schoolid",
-        "schoolid",
-        "schoolid",
-        "schoolid",
-        "childid",
-        "childid",
-        "childid",
-        "childid"
-      ),
+      Group = rep(c("schoolid", "childid"), each = 4),
       Variable = c(
         "lowinc",
         "female",
@@ -217,27 +204,22 @@ test_that("check_group_variation, multiple by", {
         "within",
         "both"
       ),
-      Design = c("nested", rep(NA_character_, 7))
+      Design = rep(c("nested", NA_character_), c(1, 7))
     ),
     ignore_attr = TRUE
   )
+  expect_equal(out7$Eta[-c(2, 4, 8)], c(1, 0, 1, 1, 0))
+  expect_true(all(0.25 < out7$Eta[c(2, 4, 8)] & out7$Eta[c(2, 4, 8)] < 0.6))
 
-  out <- check_group_variation(egsingle, by = c("schoolid", "childid"), include_by = TRUE)
+  out8 <- check_group_variation(
+    egsingle,
+    by = c("schoolid", "childid"),
+    include_by = TRUE
+  )
   expect_equal(
-    out,
+    out8[, c("Group", "Variable", "Variation", "Design")],
     data.frame(
-      Group = c(
-        "schoolid",
-        "schoolid",
-        "schoolid",
-        "schoolid",
-        "schoolid",
-        "childid",
-        "childid",
-        "childid",
-        "childid",
-        "childid"
-      ),
+      Group = rep(c("schoolid", "childid"), each = 5),
       Variable = c(
         "childid",
         "lowinc",
@@ -262,10 +244,12 @@ test_that("check_group_variation, multiple by", {
         "within",
         "both"
       ),
-      Design = c("nested", "nested", rep(NA_character_, 8))
+      Design = rep(c("nested", NA_character_), c(2, 8))
     ),
     ignore_attr = TRUE
   )
+  expect_equal(out8$Eta[-c(1, 3, 5, 10)], c(1, 0, 1, 1, 1, 0))
+  expect_true(all(0.25 < out8$Eta[c(1, 3, 5, 10)] & out8$Eta[c(1, 3, 5, 10)] < 0.8))
 })
 
 
@@ -289,7 +273,8 @@ test_that("check_group_variation, models", {
       Group = "Subject",
       Variable = "Days",
       Variation = "within",
-      Design = NA_character_
+      Design = NA_character_,
+      Eta = 0
     ),
     ignore_attr = TRUE
   )
@@ -297,7 +282,7 @@ test_that("check_group_variation, models", {
 
 test_that("check_group_variation, numeric_as_factor", {
   egsingle <- data.frame(
-    schoolid = rep(c(2020, 2820), times = c(18, 6)),
+    schoolid = factor(rep(c("2020", "2820"), times = c(18, 6))),
     lowinc = rep(c(TRUE, FALSE), times = c(18, 6)),
     childid = factor(rep(
       c("288643371", "292020281", "292020361", "295341521"),
@@ -305,32 +290,11 @@ test_that("check_group_variation, numeric_as_factor", {
     )),
     female = rep(c(TRUE, FALSE), each = 12),
     year = rep(1:6, times = 4),
-    math = c(
-      -3.068,
-      -1.13,
-      -0.921,
-      0.463,
-      0.021,
-      2.035,
-      -2.732,
-      -2.097,
-      -0.988,
-      0.227,
-      0.403,
-      1.623,
-      -2.732,
-      -1.898,
-      -0.921,
-      0.587,
-      1.578,
-      2.3,
-      -2.288,
-      -2.162,
-      -1.631,
-      -1.555,
-      -0.725,
-      0.097
-    )
+    # fmt: skip
+    math = c(-3.068, -1.13, -0.921, 0.463, 0.021, 2.035, -2.732, -2.097,
+             -0.988, 0.227, 0.403, 1.623, -2.732, -1.898, -0.921, 0.587,
+             1.578, 2.3, -2.288, -2.162, -1.631, -1.555, -0.725, 0.097),
+    stringsAsFactors = FALSE
   )
 
   out1 <- check_group_variation(egsingle, by = c("schoolid", "childid"))

--- a/tests/testthat/test-check_group_variation.R
+++ b/tests/testthat/test-check_group_variation.R
@@ -29,6 +29,9 @@ test_that("check_group_variation-1", {
     ignore_attr = TRUE
   )
 
+  expect_identical(out1$Eta[out1$Variation %in% "between"], c(1, 1))
+  expect_identical(out1$Eta[out1$Variation %in% "within"], 0)
+  expect_false(any(out1$Eta[!out1$Variation %in% c("between", "within")] %in% c(1, 0)))
   expect_identical(out1$Eta[1:4], c(NA, 1, 1, 0))
   expect_true(all(0.45 < out1$Eta[5:6] & out1$Eta[5:6] < 0.75))
 
@@ -73,6 +76,9 @@ test_that("check_group_variation-1", {
     ignore_attr = TRUE
   )
 
+  expect_identical(out2$Eta[out2$Variation %in% "between"], c(1, 1))
+  expect_identical(out2$Eta[out2$Variation %in% "within"], c(0, 0))
+  expect_false(any(out2$Eta[!out2$Variation %in% c("between", "within")] %in% c(1, 0)))
   expect_identical(out2$Eta[-c(3, 6)], c(1, 0, 1, 0))
   expect_true(all(0.7 < out2$Eta[c(3, 6)] & out2$Eta[c(3, 6)] < 0.8))
 })
@@ -157,6 +163,10 @@ test_that("check_group_variation-2", {
     ),
     ignore_attr = TRUE
   )
+
+  expect_identical(out6$Eta[out6$Variation %in% "between"], c(1, 1, 1))
+  expect_equal(out6$Eta[out6$Variation %in% "within"], 0)
+  expect_false(any(out6$Eta[!out6$Variation %in% c("between", "within")] %in% c(1, 0)))
   expect_equal(out6$Eta[-(2:3)], c(1, 1, 0, 1))
   expect_true(all(0.8 < out6$Eta[2:3] & out6$Eta[2:3] < 0.85))
 })
@@ -208,7 +218,10 @@ test_that("check_group_variation, multiple by", {
     ),
     ignore_attr = TRUE
   )
-  expect_equal(out7$Eta[-c(2, 4, 8)], c(1, 0, 1, 1, 0))
+  expect_identical(out7$Eta[out7$Variation %in% "between"], c(1, 1, 1))
+  expect_identical(out7$Eta[out7$Variation %in% "within"], c(0, 0))
+  expect_false(any(out7$Eta[!out7$Variation %in% c("between", "within")] %in% c(1, 0)))
+  expect_identical(out7$Eta[-c(2, 4, 8)], c(1, 0, 1, 1, 0))
   expect_true(all(0.25 < out7$Eta[c(2, 4, 8)] & out7$Eta[c(2, 4, 8)] < 0.6))
 
   out8 <- check_group_variation(
@@ -248,7 +261,10 @@ test_that("check_group_variation, multiple by", {
     ),
     ignore_attr = TRUE
   )
-  expect_equal(out8$Eta[-c(1, 3, 5, 10)], c(1, 0, 1, 1, 1, 0))
+  expect_identical(out8$Eta[out8$Variation %in% "between"], c(1, 1, 1, 1))
+  expect_identical(out8$Eta[out8$Variation %in% "within"], c(0, 0))
+  expect_false(any(out8$Eta[!out8$Variation %in% c("between", "within")] %in% c(1, 0)))
+  expect_identical(out8$Eta[-c(1, 3, 5, 10)], c(1, 0, 1, 1, 1, 0))
   expect_true(all(0.25 < out8$Eta[c(1, 3, 5, 10)] & out8$Eta[c(1, 3, 5, 10)] < 0.8))
 })
 


### PR DESCRIPTION
This PR adds an `Eta` column to the output of `check_group_variation()` which is a numeric effect size of the grouping variable's predictive association strength: when it is 0 the grouping variable carries no predictive information, when it is 1 the variable is perfectly predicted by the grouping variable. 
- For numeric variables it is the `sqrt(`[`icc`](https://easystats.github.io/performance/reference/icc.html)`)` - also know as $\eta$ (eta).
- For non-numeric variables it is a _non-symmetric_ version of [Cramer's _V_](https://easystats.github.io/effectsize/reference/phi.html).

``` r
performance::check_group_variation(
  mlmRev::egsingle,
  by = c("schoolid", "childid"),
  include_by = TRUE
)
#> Check schoolid variation
#> 
#> Variable | Variation |  Design |     r
#> --------------------------------------
#> childid  |      both |  nested |  .430
#> year     |      both |         |  .171
#> grade    |      both |         |  .185
#> math     |      both |         |  .358
#> retained |      both |         |  .203
#> female   |    within | crossed |  .183
#> black    |      both |         |  .824
#> hispanic |      both |         |  .692
#> size     |   between |         | 1.000
#> lowinc   |   between |         | 1.000
#> mobility |   between |         | 1.000
#> 
#> Check childid variation
#> 
#> Variable | Variation | Design |     r
#> -------------------------------------
#> schoolid |   between |        | 1.000
#> year     |      both |        |  .416
#> grade    |      both |        |  .429
#> math     |      both |        |  .713
#> retained |      both |        |  .478
#> female   |   between |        | 1.000
#> black    |   between |        | 1.000
#> hispanic |   between |        | 1.000
#> size     |   between |        | 1.000
#> lowinc   |   between |        | 1.000
#> mobility |   between |        | 1.000
```

<sup>Created on 2026-08-06 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

