### PR TITLE
Count parameters, not components, in the adjusted McFadden penalty

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: performance
 Title: Assessment of Regression Models Performance
-Version: 0.17.1.6
+Version: 0.17.1.7
 Authors@R:
     c(person(given = "Daniel",
              family = "Lüdecke",

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,12 @@
 
 ## Bug fixes
 
+* `r2_mcfadden()` now uses the number of estimated parameters in the penalty
+  of the adjusted R2. Previously the component list returned by
+  `insight::find_parameters()` was counted instead of the parameters inside
+  it, so the penalty was almost always 1 and the adjusted value barely
+  differed from the unadjusted one (#933).
+
 * `check_collinearity()` now properly warns when the `vcov` matrix is rank
   deficient (#922).
 

--- a/R/r2_mcfadden.R
+++ b/R/r2_mcfadden.R
@@ -33,7 +33,10 @@ r2_mcfadden <- function(model, ...) {
 
 .r2_mcfadden <- function(model, l_null) {
   l_full <- insight::get_loglikelihood(model)
-  k <- length(insight::find_parameters(model))
+  # number of estimated parameters, for the adjustment penalty. Not
+  # `length(find_parameters(model))`: that counts the model components
+  # (usually 1), not the parameters inside them (#933).
+  k <- insight::n_parameters(model)
   mcfadden <- 1 - (as.vector(l_full) / as.vector(l_null))
   mcfadden_adjusted <- 1 - ((as.vector(l_full) - k) / as.vector(l_null))
 

--- a/tests/testthat/test-r2_mcfadden.R
+++ b/tests/testthat/test-r2_mcfadden.R
@@ -12,7 +12,7 @@ test_that("r2_mcfadden", {
         structure(
           list(
             R2 = c(`McFadden's R2` = 0.0465152150591893),
-            R2_adjusted = c(`adjusted McFadden's R2` = 0.0459671013089695)
+            R2_adjusted = c(`adjusted McFadden's R2` = 0.0421303069)
           ),
           model_type = "Generalized Linear",
           class = "r2_generic"
@@ -86,4 +86,25 @@ test_that("r2, glmmTMB negative-binomial without random effects", {
   # nbinom1 is handled by the same branch.
   m1 <- glmmTMB::glmmTMB(y ~ 1 + x, data = dd, family = glmmTMB::nbinom1())
   expect_equal(r2(m1)$R2, 0.1406573, tolerance = 1e-4, ignore_attr = TRUE)
+})
+
+test_that("adjusted McFadden's R2 penalizes by the number of parameters", {
+  m <- glm(am ~ mpg + hp + wt, data = mtcars, family = binomial)
+  out <- r2_mcfadden(m)
+
+  ll_full <- as.vector(insight::get_loglikelihood(m))
+  ll_null <- as.vector(insight::get_loglikelihood(insight::null_model(m)))
+  k <- insight::n_parameters(m)
+
+  expect_identical(k, 4L)
+  expect_equal(
+    out$R2_adjusted,
+    1 - ((ll_full - k) / ll_null),
+    tolerance = 1e-6,
+    ignore_attr = TRUE
+  )
+
+  # reference values from DescTools::PseudoR2(m, c("McFadden", "McFaddenAdj"))
+  expect_equal(out$R2, 0.7972202, tolerance = 1e-5, ignore_attr = TRUE)
+  expect_equal(out$R2_adjusted, 0.6121632, tolerance = 1e-5, ignore_attr = TRUE)
 })


### PR DESCRIPTION
Fixes #933, and the diagnosis there is exactly right.

`.r2_mcfadden()` computed the penalty as `k <- length(insight::find_parameters(model))`. `find_parameters()` returns a list of components, so for a plain GLM this is `length(list(conditional = ...))` = 1, whatever the model. The adjustment was effectively `(logLik - 1) / logLik0` for every model, and the adjusted value barely moved away from the unadjusted one.

On the reprex from the issue, `glm(am ~ mpg + hp + wt, family = binomial)` on mtcars: the package reported an adjusted R2 of 0.751 with the true value being 0.612. After switching to `insight::n_parameters(model)` (k = 4 here), both values agree with `DescTools::PseudoR2(m, c("McFadden", "McFaddenAdj"))` to all printed digits (0.7972202 / 0.6121632), and the new regression test pins the closed form `1 - (logLik - k)/logLik0` directly.

One existing expectation had encoded the old behavior: the polr test in `test-r2_mcfadden.R` expected an adjusted R2 of 0.04597, which is the k = 1 value. With the model's 8 parameters counted (6 coefficients + 2 thresholds, verified by hand) the adjusted value is 0.04213, and the expectation is updated accordingly.

I checked the rest of the package for the same pattern: `r2_zeroinflated()`, `check_overdispersion()` and `performance_aicc()` all count parameters correctly (they use `[["conditional"]]` or `flatten = TRUE`), so this was the only site.

Version bumped to 0.17.1.7.