### PR TITLE
flip Log_loss so the best model ranks first

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: performance
 Title: Assessment of Regression Models Performance
-Version: 0.17.1.7
+Version: 0.17.1.8
 Authors@R:
     c(person(given = "Daniel",
              family = "Lüdecke",

--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,11 @@
 
 ## Bug fixes
 
+* `compare_performance(rank = TRUE)` now ranks `Log_loss` in the right
+  direction. It was normalized along with the other indices but never flipped,
+  so the model with the largest log-loss got the highest performance score and
+  the best-fitting model was listed last (#917).
+
 * `r2_mcfadden()` now uses the number of estimated parameters in the penalty
   of the adjusted R2. Previously the component list returned by
   `insight::find_parameters()` was counted instead of the parameters inside

--- a/R/compare_performance.R
+++ b/R/compare_performance.R
@@ -333,8 +333,12 @@ plot.compare_performance <- function(x, ...) {
     i
   })
 
-  # recode some indices, so higher values = better fit
-  for (i in c("RMSE", "Sigma")) {
+  # recode some indices, so higher values = better fit. Log_loss belongs here
+  # for the same reason RMSE does: it is an error measure, so the model with
+  # the smallest value is the best one. The scoring rules do not: Score_log
+  # runs over [-Inf, 0] and Score_spherical over [0, 1], and both are already
+  # oriented so that larger is better.
+  for (i in c("RMSE", "Sigma", "Log_loss")) {
     if (i %in% colnames(out)) {
       out[[i]] <- 1 - out[[i]]
     }

--- a/tests/testthat/test-compare_performance.R
+++ b/tests/testthat/test-compare_performance.R
@@ -260,5 +260,6 @@ test_that("compare_performance, RMSE and Sigma still rank in the right direction
 
   expect_identical(out$Name, c("l_best", "l_worst"))
   expect_true(all(diff(out$RMSE) > 0))
+  expect_true(all(diff(out$Sigma) > 0))
   expect_true(all(diff(out$Performance_Score) < 0))
 })

--- a/tests/testthat/test-compare_performance.R
+++ b/tests/testthat/test-compare_performance.R
@@ -233,3 +233,32 @@ test_that("compare_performance, lavaan", {
     )
   )
 })
+
+
+test_that("compare_performance, Log_loss ranks in the right direction", {
+  data(mtcars)
+  m_best <- glm(am ~ mpg + hp + wt, data = mtcars, family = binomial())
+  m_mid <- glm(am ~ mpg, data = mtcars, family = binomial())
+  m_worst <- glm(am ~ 1, data = mtcars, family = binomial())
+
+  out <- compare_performance(m_best, m_mid, m_worst, metrics = "LOGLOSS", rank = TRUE)
+
+  # log-loss is an error measure, so the smallest value is the best model and
+  # must come first once the table is ranked (#917)
+  expect_identical(out$Name, c("m_best", "m_mid", "m_worst"))
+  expect_true(all(diff(out$Log_loss) > 0))
+  expect_true(all(diff(out$Performance_Score) < 0))
+})
+
+
+test_that("compare_performance, RMSE and Sigma still rank in the right direction", {
+  data(mtcars)
+  l_best <- lm(mpg ~ wt + cyl + hp, data = mtcars)
+  l_worst <- lm(mpg ~ 1, data = mtcars)
+
+  out <- compare_performance(l_best, l_worst, metrics = c("RMSE", "SIGMA"), rank = TRUE)
+
+  expect_identical(out$Name, c("l_best", "l_worst"))
+  expect_true(all(diff(out$RMSE) > 0))
+  expect_true(all(diff(out$Performance_Score) < 0))
+})


### PR DESCRIPTION
Fixes #917 (the log-loss half).

`.rank_performance_indices()` normalizes every numeric index and then flips the ones where smaller is better, but that list was only `c("RMSE", "Sigma")`. `Log_loss` is an error measure too, so it went into the ranking un-flipped and the ordering came out backwards. On three nested logistic models the best model (log-loss 0.137) scored 0.00% and the worst (0.675) scored 100.00%:

```r
m_best  <- glm(am ~ mpg + hp + wt, data = mtcars, family = binomial())
m_mid   <- glm(am ~ mpg, data = mtcars, family = binomial())
m_worst <- glm(am ~ 1, data = mtcars, family = binomial())
compare_performance(m_best, m_mid, m_worst, metrics = "LOGLOSS", rank = TRUE)

#> Name    | Model | Log_loss | Performance-Score
#> ----------------------------------------------
#> m_worst |   glm |    0.675 |           100.00%
#> m_mid   |   glm |    0.464 |            60.67%
#> m_best  |   glm |    0.137 |             0.00%